### PR TITLE
Include zone alignment for resource validation function

### DIFF
--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -167,6 +167,21 @@ function Test-SilkResourceDeployment
                 Default: Username "azureuser" with secure password for testing purposes.
                 Used for VM deployment supplied out of necessity with no expectation to actually use the credential.
 
+            .PARAMETER ZoneAlignmentSubscriptionId
+                Azure Subscription ID for cross-subscription availability zone alignment comparison.
+                When specified, the function identifies zone alignment between the deployment subscription and this
+                given subscription, automatically adjusting deployment zone to ensure the closest representation of a production deployment that can be tested.
+                Requires AvailabilityZonePeering Azure feature registration in both subscriptions.
+                When using ChecklistJSON with different deployment subscription, this is automatically populated.
+                This will always be reported on if available but will not align the deployment zone if the -DisableZoneAlignment switch parameter is specified.
+                Example: "87654321-4321-4321-4321-210987654321"
+
+            .PARAMETER DisableZoneAlignment
+                Switch parameter to disable automatic availability zone alignment validation and adjustment.
+                By default, zone alignment is performed when ZoneAlignmentSubscriptionId is specified or when using
+                ChecklistJSON configuration with different deployment subscription. Use this switch to maintain the
+                originally specified zone for production deployment testing accuracy. Availability Zone alignment will still be reported on if available.
+
             .EXAMPLE
                 Test-SilkResourceDeployment -SubscriptionId "12345678-1234-1234-1234-123456789012" -ResourceGroupName "silk-test-rg" -Region "eastus" -Zone "1" -CNodeFriendlyName "Increased_Logical_Capacity" -CNodeCount 2 -MnodeSizeLaosv4 @("14.67","29.34") -Verbose
 
@@ -191,6 +206,19 @@ function Test-SilkResourceDeployment
 
                 Advanced deployment using explicit SKUs: 4 CNodes with E64s_v5 SKU and 2 MNode groups with mixed L-series SKUs.
                 Disables automatic cleanup so resources remain for extended testing or manual validation.
+
+            .EXAMPLE
+                Test-SilkResourceDeployment -SubscriptionId "12345678-1234-1234-1234-123456789012" -ResourceGroupName "silk-test-rg" -Region "eastus" -Zone "1" -ZoneAlignmentSubscriptionId "87654321-4321-4321-4321-210987654321" -CNodeFriendlyName "Increased_Logical_Capacity" -CNodeCount 2 -Verbose
+
+                Tests deployment with cross-subscription zone alignment validation between deployment subscription and alignment subscription.
+                Automatically adjusts deployment zone to ensure the closest representation of a production deployment that can be tested.
+                Requires AvailabilityZonePeering feature registration in both subscriptions.
+
+            .EXAMPLE
+                Test-SilkResourceDeployment -ChecklistJSON "C:\configs\silk-deployment.json" -SubscriptionId "12345678-1234-1234-1234-123456789012" -DisableZoneAlignment -Verbose
+
+                Loads configuration from JSON file but uses a different deployment subscription than specified in the JSON.
+                Explicitly disables zone alignment to maintain original zone settings despite cross-subscription deployment scenario.
 
             .INPUTS
                 Command line parameters or JSON configuration file containing deployment specifications.

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -1183,14 +1183,22 @@ function Test-SilkResourceDeployment
                 # SKU Configuration Identification and Validation
                 # ===============================================================================
                 # Set MNode size from parameter values when not using JSON configuration
-                if (!$MNodeSize -and $ConfigImport <# DELETE once PV2 Supported>>>#> -and $ConfigImport.sdp.m_node_type -and $ConfigImport.sdp.m_node_type -ne "PV2" <# !<<<< DELETE once PV2 Supported#> )
+                if (!$MNodeSize -and $ConfigImport)
+                    {
                         ##################### !
                         #! No PV2 support presently
                         #! zero out the mnode values if PV2 is selected
                         #! delete once PV2 is supported
                         ##################### !
-                    {
-                        $MNodeSize = $ConfigImport.sdp.m_node_sizes
+                        if(<# DELETE once PV2 Supported>>>#> $ConfigImport.sdp.m_node_type -and $ConfigImport.sdp.m_node_type -eq "PV2" <# !<<<< DELETE once PV2 Supported#> )
+                            {
+                                Write-Error -Message $("PV2 MNode type is not currently supported. Please select Lsv3 or Laosv4 MNode types.")
+                            }
+                        else
+                            {
+                                # ! Keep this Part VVVV
+                                $MNodeSize = $ConfigImport.sdp.m_node_sizes
+                            }
                     } `
                 elseif ($MnodeSizeLsv3)
                     {

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -854,7 +854,7 @@ function Test-SilkResourceDeployment
                             } `
                         else
                             {
-                                Write-Warning -Message $("Subscription ID parameter is set to '{0}', ignoring subscription ID in JSON configuration." -f $SubscriptionId)
+                                Write-Warning -Message $("Subscription ID parameter is set to '{0}', ignoring subscription ID '{1}' in JSON configuration." -f $SubscriptionId, $ConfigImport.azure_environment.subscription_id)
                             }
 
                         if (!$ResourceGroupName)
@@ -863,7 +863,7 @@ function Test-SilkResourceDeployment
                             } `
                         else
                             {
-                                Write-Warning -Message $("Resource Group Name parameter is set to '{0}', ignoring resource group name in JSON configuration." -f $ResourceGroupName)
+                                Write-Warning -Message $("Resource Group Name parameter is set to '{0}', ignoring resource group name '{1}' in JSON configuration." -f $ResourceGroupName, $ConfigImport.azure_environment.resource_group_name)
                             }
 
                         if(!$Region)
@@ -872,7 +872,7 @@ function Test-SilkResourceDeployment
                             } `
                         else
                             {
-                                Write-Warning -Message $("Region parameter is set to '{0}', ignoring region in JSON configuration." -f $Region)
+                                Write-Warning -Message $("Region parameter is set to '{0}', ignoring region '{1}' in JSON configuration." -f $Region, $ConfigImport.azure_environment.region)
                             }
 
                         if(!$Zone)
@@ -881,7 +881,7 @@ function Test-SilkResourceDeployment
                             } `
                         else
                             {
-                                Write-Warning -Message $("Zone parameter is set to '{0}', ignoring zone in JSON configuration." -f $Zone)
+                                Write-Warning -Message $("Zone parameter is set to '{0}', ignoring zone '{1}' in JSON configuration." -f $Zone, $ConfigImport.azure_environment.zone)
                             }
 
                         # identify cnode count

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -1044,19 +1044,21 @@ function Test-SilkResourceDeployment
                         $locationSupportedSKU = Get-AzComputeResourceSku -Location $Region -ErrorAction Stop
 
                         # Check zone availability
-                        if ($Zone -notin $locationSupportedSKU.LocationInfo.Zones)
-                            {
-                                Write-Error -Message $("The specified zone '{0}' is not available in the region '{1}'." -f $Zone, $Region)
-                                return
-                            } `
-                        elseif ($Zone -eq "Zoneless" -and $locationSupportedSKU.LocationInfo.Zones.Count -ne 0)
+                        if ($Zone -eq "Zoneless" -and $locationSupportedSKU.LocationInfo.Zones.Count -ne 0)
                             {
                                 Write-Error -Message $("The specified region '{0}' has availability zones {1}, but 'Zoneless' was specified." -f ($locationSupportedSKU.LocationInfo.Location | Select-Object -Unique), (($locationSupportedSKU.LocationInfo.Zones | Sort-Object | Select-Object -Unique) -join ", "))
+                                $validationError = $true
                                 return
                             } `
                         elseif ($Zone -eq "Zoneless")
                             {
                                 Write-Verbose -Message $("Zoneless is a valid zone selection for the specified region '{0}'." -f ($locationSupportedSKU.LocationInfo.Location | Select-Object -Unique))
+                            } `
+                        elseif ($Zone -notin $locationSupportedSKU.LocationInfo.Zones)
+                            {
+                                Write-Error -Message $("The specified zone '{0}' is not available in the region '{1}'." -f $Zone, $Region)
+                                $validationError = $true
+                                return
                             } `
                         else
                             {

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -33,8 +33,8 @@ function Test-SilkResourceDeployment
                 - MNodes: Media nodes that coordinate data operations and storage management
                 - DNodes: Data nodes that store and serve data (deployed as part of MNode groups)
 
-                Function Version: 1.97.9-1.0.0
-                Supporting Silk SDP configurations from version 1.97.9
+                Function Version: 1.98.9-1.0.1
+                Supporting Silk SDP configurations from version 1.98.9
 
             .PARAMETER SubscriptionId
                 Azure Subscription ID where resources will be deployed.

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -851,6 +851,7 @@ function Test-SilkResourceDeployment
                         if (!$SubscriptionId)
                             {
                                 $SubscriptionId = $ConfigImport.azure_environment.subscription_id
+                                Write-Verbose -Message $("Using subscription ID '{0}' from JSON configuration." -f $SubscriptionId)
                             } `
                         else
                             {
@@ -860,6 +861,7 @@ function Test-SilkResourceDeployment
                         if (!$ResourceGroupName)
                             {
                                 $ResourceGroupName = $ConfigImport.azure_environment.resource_group_name
+                                Write-Verbose -Message $("Using resource group name '{0}' from JSON configuration." -f $ResourceGroupName)
                             } `
                         else
                             {
@@ -869,6 +871,7 @@ function Test-SilkResourceDeployment
                         if(!$Region)
                             {
                                 $Region = $ConfigImport.azure_environment.region
+                                Write-Verbose -Message $("Using region '{0}' from JSON configuration." -f $Region)
                             } `
                         else
                             {
@@ -878,6 +881,7 @@ function Test-SilkResourceDeployment
                         if(!$Zone)
                             {
                                 $Zone = $ConfigImport.azure_environment.zone
+                                Write-Verbose -Message $("Using zone '{0}' from JSON configuration." -f $Zone)
                             } `
                         else
                             {

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -180,7 +180,7 @@ function Test-SilkResourceDeployment
                 Switch parameter to disable automatic availability zone alignment validation and adjustment.
                 By default, zone alignment is performed when ZoneAlignmentSubscriptionId is specified or when using
                 ChecklistJSON configuration with different deployment subscription. Use this switch to maintain the
-                originally specified zone for production deployment testing accuracy. Availability Zone alignment will still be reported on if available.
+                originally specified zone. Availability Zone alignment will still be reported on if available.
 
             .EXAMPLE
                 Test-SilkResourceDeployment -SubscriptionId "12345678-1234-1234-1234-123456789012" -ResourceGroupName "silk-test-rg" -Region "eastus" -Zone "1" -CNodeFriendlyName "Increased_Logical_Capacity" -CNodeCount 2 -MnodeSizeLaosv4 @("14.67","29.34") -Verbose
@@ -2718,7 +2718,7 @@ function Test-SilkResourceDeployment
                             {
                                 $zoneAlignmentInfo.AlignmentPerformed = $true
                                 $zoneAlignmentInfo.OriginalZone = $originalZone
-                                $zoneAlignmentInfo.AlignmentReason = "Zone alignment applied for production deployment testing accuracy"
+                                $zoneAlignmentInfo.AlignmentReason = "Zone alignment applied"
                             } `
                         elseif ($DisableZoneAlignment -and $alignedZone)
                             {

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -253,6 +253,7 @@ function Test-SilkResourceDeployment
                 [Parameter(ParameterSetName = "Mnode Lsv3",                     Mandatory = $true,  HelpMessage = "Enter your Azure Subscription ID (GUID format). Example: 12345678-1234-1234-1234-123456789012")]
                 [Parameter(ParameterSetName = "Mnode Laosv4",                   Mandatory = $true,  HelpMessage = "Enter your Azure Subscription ID (GUID format). Example: 12345678-1234-1234-1234-123456789012")]
                 [Parameter(ParameterSetName = "Mnode by SKU",                   Mandatory = $true,  HelpMessage = "Enter your Azure Subscription ID (GUID format). Example: 12345678-1234-1234-1234-123456789012")]
+                [ValidatePattern('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')]
                 [ValidateNotNullOrEmpty()]
                 [string]
                 $SubscriptionId,
@@ -274,6 +275,7 @@ function Test-SilkResourceDeployment
                 [Parameter(ParameterSetName = "Mnode Lsv3",                     Mandatory = $true,  HelpMessage = "Enter the name of an existing Azure Resource Group where test resources will be deployed. Example: my-test-rg")]
                 [Parameter(ParameterSetName = "Mnode Laosv4",                   Mandatory = $true,  HelpMessage = "Enter the name of an existing Azure Resource Group where test resources will be deployed. Example: my-test-rg")]
                 [Parameter(ParameterSetName = "Mnode by SKU",                   Mandatory = $true,  HelpMessage = "Enter the name of an existing Azure Resource Group where test resources will be deployed. Example: my-test-rg")]
+                [ValidatePattern('^[a-z][a-z0-9\-]{1,61}[a-z0-9]$')]
                 [ValidateNotNullOrEmpty()]
                 [string]
                 $ResourceGroupName,
@@ -491,6 +493,7 @@ function Test-SilkResourceDeployment
                 [Parameter(ParameterSetName = "Mnode Lsv3",                     Mandatory = $false, HelpMessage = "Specify VNet CIDR range for VNET and subnet IP space. Example: 10.0.0.0/24")]
                 [Parameter(ParameterSetName = "Mnode Laosv4",                   Mandatory = $false, HelpMessage = "Specify VNet CIDR range for VNET and subnet IP space. Example: 10.0.0.0/24")]
                 [Parameter(ParameterSetName = "Mnode by SKU",                   Mandatory = $false, HelpMessage = "Specify VNet CIDR range for VNET and subnet IP space. Example: 10.0.0.0/24")]
+                [ValidatePattern('^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$')]
                 [ValidateNotNullOrEmpty()]
                 [string]
                 $IPRangeCIDR,

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -681,6 +681,7 @@ function Test-SilkResourceDeployment
 
         begin
             {
+                $StartTime = Get-Date
 
                 # Define required Azure PowerShell modules
                 # Import only the specific modules needed instead of the entire Az module for faster loading
@@ -1675,7 +1676,7 @@ function Test-SilkResourceDeployment
                                     }
                             }
 
-                        $ReportFullPath = Join-Path -Path $ReportOutputPath -ChildPath $("SilkDeploymentReport_{0}.html" -f $(Get-Date -Format "yyyyMMdd_HHmmss"))
+                        $ReportFullPath = Join-Path -Path $ReportOutputPath -ChildPath $("SilkDeploymentReport_{0}.html" -f $StartTime.ToString("yyyyMMdd_HHmmss"))
                         Write-Verbose -Message $("HTML report will be generated at: {0}" -f $ReportFullPath)
                     }
 
@@ -2437,7 +2438,7 @@ function Test-SilkResourceDeployment
                                             AlternativeZones = $alternativeZones
                                             TestedZone = $Zone
                                             TestedRegion = $Region
-                                            Timestamp = Get-Date
+                                            Timestamp = $StartTime
                                         }
 
                                         # Log deployment validation findings appropriately based on failure type
@@ -3227,7 +3228,7 @@ function Test-SilkResourceDeployment
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Silk Azure Deployment Report - $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')</title>
+    <title>Silk Azure Deployment Report - $($StartTime.ToString("yyyy-MM-dd HH:mm:ss"))</title>
     <style>
         body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; margin: 0; padding: 20px; background-color: #f5f5f5; line-height: 1.6; }
         .container { max-width: 1200px; margin: 0 auto; background: white; padding: 30px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
@@ -3748,7 +3749,7 @@ function Test-SilkResourceDeployment
         </div>
 
         <div class="timestamp">
-            Report generated on $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') by Test-SilkResourceDeployment PowerShell module
+            Report generated on $($StartTime.ToString("yyyy-MM-dd HH:mm:ss")) by Silk Test-SilkResourceDeployment PowerShell module
         </div>
     </div>
 </body>

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -1050,6 +1050,12 @@ function Test-SilkResourceDeployment
                                 $validationError = $true
                                 return
                             } `
+                        elseif ($locationSupportedSKU.LocationInfo.Zones.Count -eq 0 -and $Zone -ne "Zoneless")
+                            {
+                                Write-Warning -Message $("The specified region '{0}' has no Availability Zones, but Zone value {1} was specified instead of 'Zoneless'." -f ($locationSupportedSKU.LocationInfo.Location | Select-Object -Unique), $Zone)
+                                Write-Warning -Message $("Changing deployment Zone selection from '{0}' to 'Zoneless' and deploying in Region {1}." -f $Zone, $Region)
+                                $Zone = "Zoneless"
+                            } `
                         elseif ($Zone -eq "Zoneless")
                             {
                                 Write-Verbose -Message $("Zoneless is a valid zone selection for the specified region '{0}'." -f ($locationSupportedSKU.LocationInfo.Location | Select-Object -Unique))

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -899,19 +899,23 @@ function Test-SilkResourceDeployment
                                 Write-Warning -Message $("Subscription ID parameter is set to '{0}', ignoring subscription ID '{1}' in JSON configuration." -f $SubscriptionId, $ConfigImport.azure_environment.subscription_id)
                             }
 
-                        # Zone alignment subscription ID is optional - only set if provided in JSON or parameter
-                        if (!$ZoneAlignmentSubscriptionId -and $SubscriptionId)
+                        # Availability Zone alignment subscription ID is optional - only set if provided in JSON or parameter
+                        if (!$ZoneAlignmentSubscriptionId -and $SubscriptionId -ne $ConfigImport.azure_environment.subscription_id)
                             {
                                 $ZoneAlignmentSubscriptionId = $ConfigImport.azure_environment.subscription_id
-                                Write-Verbose -Message $("Usingsubscription ID '{0}' from JSON configuration for zone alignment comparison." -f $ZoneAlignmentSubscriptionId)
+                                Write-Verbose -Message $("Using Subscription ID '{0}' from JSON configuration for Availability Zone alignment comparison." -f $ZoneAlignmentSubscriptionId)
                             } `
+                        elseif (!$ZoneAlignmentSubscriptionId -and $SubscriptionId -eq $ConfigImport.azure_environment.subscription_id)
+                            {
+                                Write-Warning -Message $("Subscription ID parameter is: '{0}' matchint the Checklist Imported Subscription ID is: '{1}'. No Availability Zone alignment required." -f $ZoneAlignmentSubscriptionId, $ConfigImport.azure_environment.subscription_id)
+                            }
                         elseif ($ZoneAlignmentSubscriptionId)
                             {
-                                Write-Warning -Message $("Zone Alignment Subscription ID parameter is set to '{0}'." -f $ZoneAlignmentSubscriptionId)
+                                Write-Warning -Message $("Availability Zone Alignment Subscription ID parameter is set to '{0}'." -f $ZoneAlignmentSubscriptionId)
                             }
                         else
                             {
-                                Write-Verbose -Message $("Zone Alignment Subscription ID is NOT set, and will not be tested.")
+                                Write-Verbose -Message $("Availability Zone Alignment Subscription ID is NOT set, and will not be tested.")
                             }
 
                         if (!$ResourceGroupName)

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -792,7 +792,7 @@ function Test-SilkResourceDeployment
                             }
 
                         # Suppress Azure PowerShell breaking change warnings for cleaner output
-                        Write-Verbose -Message "Configuring Azure PowerShell warning preferences..."
+                        Write-Verbose -Message $("Configuring Azure PowerShell warning preferences...")
                         try
                             {
                                 # Suppress breaking change warnings globally for this session
@@ -805,19 +805,19 @@ function Test-SilkResourceDeployment
                                         $WarningPreference = 'SilentlyContinue'
                                     }
 
-                                Write-Verbose -Message "✓ Azure PowerShell breaking change warnings suppressed for cleaner output."
+                                Write-Verbose -Message $("✓ Azure PowerShell breaking change warnings suppressed for cleaner output.")
                             }
                         catch
                             {
-                                Write-Verbose -Message "Warning: Could not suppress Azure PowerShell breaking change warnings."
+                                Write-Verbose -Message $("Warning: Could not suppress Azure PowerShell breaking change warnings.")
                             }
 
                         # Verify Azure authentication status
-                        Write-Verbose -Message "Checking Azure authentication status..."
+                        Write-Verbose -Message $("Checking Azure authentication status...")
                         $currentAzContext = Get-AzContext
                         if (-not $currentAzContext)
                             {
-                                Write-Warning -Message "You are not authenticated to Azure. Attempting interactive authentication..."
+                                Write-Warning -Message $("You are not authenticated to Azure. Attempting interactive authentication...")
 
                                 try
                                     {
@@ -850,15 +850,15 @@ function Test-SilkResourceDeployment
                                 try
                                     {
                                         $testConnection = Get-AzSubscription -SubscriptionId $currentAzContext.Subscription.Id -ErrorAction Stop
-                                        Write-Verbose -Message "✓ Azure authentication is valid and active."
+                                        Write-Verbose -Message $("✓ Azure authentication is valid and active.")
                                     }
                                 catch
                                     {
-                                        Write-Warning -Message "Current Azure context appears to be expired. Attempting re-authentication..."
+                                        Write-Warning -Message $("Current Azure context appears to be expired. Attempting re-authentication...")
                                         try
                                             {
                                                 $connectResult = Connect-AzAccount -ErrorAction Stop
-                                                Write-Verbose -Message "✓ Azure re-authentication successful."
+                                                Write-Verbose -Message $("✓ Azure re-authentication successful.")
                                             }
                                         catch
                                             {
@@ -868,7 +868,7 @@ function Test-SilkResourceDeployment
                                     }
                             }
 
-                        Write-Verbose -Message "=== Azure PowerShell Prerequisites Complete ==="
+                        Write-Verbose -Message $("=== Azure PowerShell Prerequisites Complete ===")
                     }
                 catch
                     {
@@ -1066,7 +1066,7 @@ function Test-SilkResourceDeployment
 
                 if ($Development)
                     {
-                        Write-Verbose -Message "Running in Development Mode, using reduced CNode configuration for faster deployment."
+                        Write-Verbose -Message $("Running in Development Mode, using reduced CNode configuration for faster deployment.")
                         $cNodeSizeObject = @(
                                                 [pscustomobject]@{vmSkuPrefix = "Standard_D"; vCPU = 2; vmSkuSuffix = "s_v5"; QuotaFamily = "Standard Dsv5 Family vCPUs"; cNodeFriendlyName = "No_Increased_Logical_Capacity"};
                                                 [pscustomobject]@{vmSkuPrefix = "Standard_L"; vCPU = 4; vmSkuSuffix = "s_v3"; QuotaFamily = "Standard Lsv3 Family vCPUs"; cNodeFriendlyName = "Read_Cache_Enabled"};
@@ -1113,7 +1113,7 @@ function Test-SilkResourceDeployment
 
                 if ($Development)
                     {
-                        Write-Verbose -Message "Running in Development Mode, using reduced MNode/DNode configuration for faster deployment."
+                        Write-Verbose -Message $("Running in Development Mode, using reduced MNode/DNode configuration for faster deployment.")
                         $mNodeSizeObject = @(
                                                 [pscustomobject]@{dNodeCount = 1; vmSkuPrefix = "Standard_L"; vCPU = 8;    vmSkuSuffix = "s_v3";   PhysicalSize = 19.5;     QuotaFamily = "Standard Lsv3 Family vCPUs"};
                                                 [pscustomobject]@{dNodeCount = 1; vmSkuPrefix = "Standard_L"; vCPU = 16;   vmSkuSuffix = "s_v3";   PhysicalSize = 39.1;     QuotaFamily = "Standard Lsv3 Family vCPUs"};
@@ -1147,7 +1147,7 @@ function Test-SilkResourceDeployment
                         $IPRangeCIDR = "10.0.0.0/24"
                     }
 
-                Write-Verbose -Message "Using IP range: $IPRangeCIDR for VNet and subnet configuration."
+                Write-Verbose -Message $("Using IP range: {0} for VNet and subnet configuration." -f $IPRangeCIDR)
 
 
                 # ===============================================================================
@@ -1181,7 +1181,7 @@ function Test-SilkResourceDeployment
                 if (!$CNodeCount -and !$CNodeFriendlyName -and !$CNodeSku -and $MnodeSize)
                     {
                         # MNode-only deployment scenario - no CNode configuration required
-                        Write-Verbose -Message "MNode-only deployment mode - CNode configuration skipped."
+                        Write-Verbose -Message $("MNode-only deployment mode - CNode configuration skipped.")
                         $cNodeObject = $null
                     } `
                 elseif ($CNodeCount -and ($CNodeFriendlyName -eq "Read_Cache_Enabled" -or $ConfigImport.sdp.read_cache_enabled))
@@ -1202,7 +1202,7 @@ function Test-SilkResourceDeployment
                     } `
                 else
                     {
-                        Write-Error "Configuration is not valid. Please specify either CNode parameters (CNodeFriendlyName/CNodeSku with CNodeCount) or MNode parameters (MnodeSizeLsv3/MnodeSizeLaosv4/MNodeSku), or both."
+                        Write-Error $("Configuration is not valid. Please specify either CNode parameters (CNodeFriendlyName/CNodeSku with CNodeCount) or MNode parameters (MnodeSizeLsv3/MnodeSizeLaosv4/MNodeSku), or both.")
                         $validationError = $true
                         return
                     }
@@ -1210,7 +1210,7 @@ function Test-SilkResourceDeployment
                 if ($cNodeObject)
                     {
                         $cNodeVMSku = "{0}{1}{2}" -f $cNodeObject.vmSkuPrefix, $cNodeObject.vCPU, $cNodeObject.vmSkuSuffix
-                        Write-Verbose -Message ("Identified CNode SKU: {0}" -f $cNodeVMSku)
+                        Write-Verbose -Message $("Identified CNode SKU: {0}" -f $cNodeVMSku)
                     }
 
                 # Initialize MNode object list to hold configuration for each MNode type
@@ -1231,11 +1231,11 @@ function Test-SilkResourceDeployment
                 elseif ($CNodeCount -and !$MnodeSizeLsv3 -and !$MnodeSizeLaosv4 -and !$MNodeSku)
                     {
                         # CNode-only deployment scenario - no MNode configuration required
-                        Write-Verbose -Message "CNode-only deployment mode - no MNode resources will be created."
+                        Write-Verbose -Message $("CNode-only deployment mode - no MNode resources will be created.")
                     } `
                 elseif (!$CNodeCount -and !$MnodeSizeLsv3 -and !$MnodeSizeLaosv4 -and !$MNodeSku)
                     {
-                        Write-Error "No valid configuration specified. Please specify either CNode parameters (CNodeFriendlyName/CNodeSku with CNodeCount) or MNode parameters (MnodeSizeLsv3/MnodeSizeLaosv4/MNodeSku), or both."
+                        Write-Error $("No valid configuration specified. Please specify either CNode parameters (CNodeFriendlyName/CNodeSku with CNodeCount) or MNode parameters (MnodeSizeLsv3/MnodeSizeLaosv4/MNodeSku), or both.")
                         $validationError = $true
                         return
                     }
@@ -1366,7 +1366,7 @@ function Test-SilkResourceDeployment
                         $cNodeSupportedSKU = $locationSupportedSKU | Where-Object Name -eq $cNodeVMSku
                         if (!$cNodeSupportedSKU)
                             {
-                                Write-Error "Unable to identify location for CNode SKU: {0} in region: {1}" -f $cNodeVMSku, $Region
+                                Write-Error $("Unable to identify location for CNode SKU: {0} in region: {1}" -f $cNodeVMSku, $Region)
                                 return
                             } `
                         elseif ($cNodeSupportedSKU -and $Zone -eq "Zoneless")
@@ -1529,13 +1529,13 @@ function Test-SilkResourceDeployment
                             } `
                         else
                             {
-                                Write-Verbose "All required quotas are available for the specified CNode and MNode configurations."
+                                Write-Verbose $("All required quotas are available for the specified CNode and MNode configurations.")
                             }
 
                     } `
                 catch
                     {
-                        Write-Error "Error occurred while checking compute quota: $_"
+                        Write-Error $("Error occurred while checking compute quota: {0}" -f $_)
                     }
 
 
@@ -1684,7 +1684,7 @@ function Test-SilkResourceDeployment
                 # ===============================================================================
                 # Deployment Configuration Summary
                 # ===============================================================================
-                Write-Verbose -Message "=== Silk Azure Deployment Configuration ==="
+                Write-Verbose -Message $("=== Silk Azure Deployment Configuration ===")
                 Write-Verbose -Message $("Subscription ID: {0}" -f $SubscriptionId)
                 Write-Verbose -Message $("Resource Group: {0}" -f $ResourceGroupName)
                 Write-Verbose -Message $("Deployment Region: {0}" -f $Region)
@@ -1699,7 +1699,7 @@ function Test-SilkResourceDeployment
                     } `
                 else
                     {
-                        Write-Verbose -Message "CNode Count: 0 (MNode-only deployment)"
+                        Write-Verbose -Message $("CNode Count: 0 (MNode-only deployment)")
                     }
 
                 if ($mNodeObject -and $mNodeObject.Count -gt 0)
@@ -1736,13 +1736,13 @@ function Test-SilkResourceDeployment
 
                 if ($Development)
                     {
-                        Write-Verbose -Message "Development Mode: ENABLED (using smaller VM sizes for faster deployment)"
+                        Write-Verbose -Message $("Development Mode: ENABLED (using smaller VM sizes for faster deployment)")
                     } `
                 else
                     {
-                        Write-Verbose -Message "Development Mode: DISABLED (deploying production VM SKUs)"
+                        Write-Verbose -Message $("Development Mode: DISABLED (deploying production VM SKUs)")
                     }
-                Write-Verbose -Message "=========================================="
+                Write-Verbose -Message $("==========================================")
             }
 
         # This block is used to provide record-by-record processing for the function.
@@ -1751,7 +1751,7 @@ function Test-SilkResourceDeployment
                 # if there is a validtion error skip deployment
                 if ($validationError)
                     {
-                        Write-Error "Validation failed. Please fix the errors and try again."
+                        Write-Error $("Validation failed. Please fix the errors and try again.")
                         return
                     }
                 # if run cleanup only, skip the process code
@@ -1820,7 +1820,7 @@ function Test-SilkResourceDeployment
                         Write-Verbose -Message $("  - Inbound Rule: '{0}' - {1} traffic from source '{2}' ports '{3}' to destination '{4}' ports '{5}' protocol '{6}' [Priority: {7}]" -f $verboseInboundRule.Name, $verboseInboundRule.Access, ($verboseInboundRule.SourceAddressPrefix -join ','), ($verboseInboundRule.SourcePortRange -join ','), ($verboseInboundRule.DestinationAddressPrefix -join ','), ($verboseInboundRule.DestinationPortRange -join ','), $verboseInboundRule.Protocol, $verboseInboundRule.Priority)
                         Write-Verbose -Message $("  - Outbound Rule: '{0}' - {1} traffic from source '{2}' ports '{3}' to destination '{4}' ports '{5}' protocol '{6}' [Priority: {7}]" -f $verboseOutboundRule.Name, $verboseOutboundRule.Access, ($verboseOutboundRule.SourceAddressPrefix -join ','), ($verboseOutboundRule.SourcePortRange -join ','), ($verboseOutboundRule.DestinationAddressPrefix -join ','), ($verboseOutboundRule.DestinationPortRange -join ','), $verboseOutboundRule.Protocol, $verboseOutboundRule.Priority)
 
-                        Write-Verbose -Message "  - Security Impact: Complete network isolation - NO traffic allowed in any direction"
+                        Write-Verbose -Message $("  - Security Impact: Complete network isolation - NO traffic allowed in any direction")
 
                         # -----------------------------------------------------------------------
                         # Subnet Configuration
@@ -1842,7 +1842,7 @@ function Test-SilkResourceDeployment
                                     -Subnet $mGMTSubnet #, $storageSubnet
 
                         Write-Verbose -Message $("✓ Virtual Network '{0}' created with address space {1}" -f $vNET.Name, $IPRangeCIDR)
-                        Write-Verbose -Message "✓ Network isolation configured: All VMs will be deployed with NO network access"
+                        Write-Verbose -Message $("✓ Network isolation configured: All VMs will be deployed with NO network access")
 
                         $mGMTSubnetID = $vNET.Subnets | Where-Object { $_.Name -eq $mGMTSubnet.Name } | Select-Object -ExpandProperty Id
                     } `
@@ -1856,9 +1856,9 @@ function Test-SilkResourceDeployment
                 try
                     {
                         # Clean up any old jobs before starting deployment to better track jobs related to the active run
-                        Write-Verbose -Message "Cleaning up any existing background jobs..."
+                        Write-Verbose -Message $("Cleaning up any existing background jobs...")
                         Get-Job | Remove-Job -Force
-                        Write-Verbose -Message "All existing jobs have been removed."
+                        Write-Verbose -Message $("All existing jobs have been removed.")
 
                         # Initialize job-to-VM mapping for meaningful error reporting
                         $vmJobMapping = @{}
@@ -3767,24 +3767,24 @@ function Test-SilkResourceDeployment
                                         if ($IsWindows -or $PSVersionTable.PSVersion.Major -le 5)
                                             {
                                                 Start-Process $ReportFullPath
-                                                Write-Verbose -Message "HTML report opened in default browser."
+                                                Write-Verbose -Message $("HTML report opened in default browser.")
                                             }
                                         elseif ($IsLinux)
                                             {
                                                 if (Get-Command xdg-open -ErrorAction SilentlyContinue)
                                                     {
                                                         & xdg-open $ReportFullPath
-                                                        Write-Verbose -Message "HTML report opened with xdg-open."
+                                                        Write-Verbose -Message $("HTML report opened with xdg-open.")
                                                     }
                                                 else
                                                     {
-                                                        Write-Verbose -Message "xdg-open not available. Report saved but not opened automatically."
+                                                        Write-Verbose -Message $("xdg-open not available. Report saved but not opened automatically.")
                                                     }
                                             }
                                         elseif ($IsMacOS)
                                             {
                                                 & open $ReportFullPath
-                                                Write-Verbose -Message "HTML report opened with macOS open command."
+                                                Write-Verbose -Message $("HTML report opened with macOS open command.")
                                             }
                                     }
                                 catch
@@ -3824,12 +3824,12 @@ function Test-SilkResourceDeployment
                         if (Get-Variable -Name originalWarningPreference -ErrorAction SilentlyContinue)
                             {
                                 $WarningPreference = $originalWarningPreference
-                                Write-Verbose -Message "✓ Original PowerShell warning preference restored."
+                                Write-Verbose -Message $("✓ Original PowerShell warning preference restored.")
                             }
                     }
                 catch
                     {
-                        Write-Verbose -Message "Note: Could not restore original warning preference."
+                        Write-Verbose -Message $("Note: Could not restore original warning preference.")
                     }
 
                 if ( $RunCleanupOnly -or (!$DisableCleanup -and $deploymentStarted))
@@ -3903,7 +3903,7 @@ function Test-SilkResourceDeployment
                                     -Id 6
 
                                 # Wait for all VM removal jobs to complete
-                                Write-Verbose -Message "Waiting for all virtual machines to be removed..."
+                                Write-Verbose -Message $("Waiting for all virtual machines to be removed...")
 
                                 $vmJobs = Get-Job
 
@@ -3946,7 +3946,7 @@ function Test-SilkResourceDeployment
                                 while ($currentVMJobs.State -contains 'Running')
 
                                 Get-Job | Wait-Job | Out-Null
-                                Write-Verbose -Message "All virtual machines have been removed."
+                                Write-Verbose -Message $("All virtual machines have been removed.")
 
                                 # Complete VM cleanup sub-progress
                                 Write-Progress `
@@ -4013,9 +4013,9 @@ function Test-SilkResourceDeployment
                                     -Status "Waiting for all NIC removal jobs to complete..." `
                                     -PercentComplete 80
 
-                                Write-Verbose -Message "Waiting for all network interfaces to be removed..."
+                                Write-Verbose -Message $("Waiting for all network interfaces to be removed...")
                                 Get-Job | Wait-Job | Out-Null
-                                Write-Verbose -Message "All network interfaces have been removed."
+                                Write-Verbose -Message $("All network interfaces have been removed.")
 
                                 Write-Progress `
                                     -Id 7 `
@@ -4086,7 +4086,7 @@ function Test-SilkResourceDeployment
 
                                 Get-Job | Wait-Job | Out-Null
 
-                                Write-Verbose -Message "Virtual Network resource cleanup completed."
+                                Write-Verbose -Message $("Virtual Network resource cleanup completed.")
 
                                 Write-Progress `
                                     -Id 9 `
@@ -4157,7 +4157,7 @@ function Test-SilkResourceDeployment
                                     Get-Job | Wait-Job | Out-Null
                                 }
 
-                                Write-Verbose -Message "Availability Sets resource cleanup completed."
+                                Write-Verbose -Message $("Availability Sets resource cleanup completed.")
 
                                 Write-Progress `
                                     -Id 11 `
@@ -4228,7 +4228,7 @@ function Test-SilkResourceDeployment
                                     Get-Job | Wait-Job | Out-Null
                                 }
 
-                                Write-Verbose -Message "Proximity Placement Groups resource cleanup completed."
+                                Write-Verbose -Message $("Proximity Placement Groups resource cleanup completed.")
 
                                 Write-Progress `
                                     -Id 12 `
@@ -4298,7 +4298,7 @@ function Test-SilkResourceDeployment
 
                                 Get-Job | Wait-Job | Out-Null
 
-                                Write-Verbose -Message "Network Security Group resource cleanup completed."
+                                Write-Verbose -Message $("Network Security Group resource cleanup completed.")
 
                                 Write-Progress `
                                     -Id 10 `
@@ -4355,7 +4355,7 @@ function Test-SilkResourceDeployment
 
                         Remove-AzResourceGroup -Name $ResourceGroupName -ErrorAction Stop -Confirm:$false
 
-                        Write-Verbose -Message "Resource group removal completed."
+                        Write-Verbose -Message $("Resource group removal completed.")
 
                         # Complete resource group cleanup progress
                         Write-Progress `

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -1396,16 +1396,18 @@ function Test-SilkResourceDeployment
                                 Write-Warning -Message $("{0}Failed to acquire Availability Zone alignment information: {1}" -f $messagePrefix, $_.Exception.Message)
                                 return
                             }
-
-
                     } `
                 elseif ($Zone -eq "Zoneless")
                     {
-                        Write-Verbose -Message -Message $("{0}Zoneless deployment; zone alignment not possible." -f $messagePrefix)
+                        Write-Verbose -Message $("{0}Deployment Availability Zone is : '{1}' Availability Zone alignment not possible." -f $messagePrefix, $Zone)
+                    } `
+                elseif ($ZoneAlignmentSubscriptionId -eq $SubscriptionId)
+                    {
+                        Write-Verbose -Message $("{0}Deployment Subscription : '{1}' is the same as Availability Zone Alignment Subscription ID: '{2}'. Availability Zone alignment not necessary." -f $messagePrefix, $Zone)
                     } `
                 else
                     {
-                        Write-Verbose -Message $("{0}Zone Alignment Subscription ID is not set; skipping zone alignment check." -f $messagePrefix)
+                        Write-Verbose -Message $("{0}Availability Zone Alignment Subscription ID is not set; skipping Availability Zone alignment check." -f $messagePrefix)
                     }
 
 

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -1153,7 +1153,12 @@ function Test-SilkResourceDeployment
                 # SKU Configuration Identification and Validation
                 # ===============================================================================
                 # Set MNode size from parameter values when not using JSON configuration
-                if (!$MNodeSize -and $ConfigImport)
+                if (!$MNodeSize -and $ConfigImport <# DELETE once PV2 Supported>>>#> -and $ConfigImport.sdp.m_node_type -and $ConfigImport.sdp.m_node_type -ne "PV2" <# !<<<< DELETE once PV2 Supported#> )
+                        ##################### !
+                        #! No PV2 support presently
+                        #! zero out the mnode values if PV2 is selected
+                        #! delete once PV2 is supported
+                        ##################### !
                     {
                         $MNodeSize = $ConfigImport.sdp.m_node_sizes
                     } `

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -728,12 +728,12 @@ function Test-SilkResourceDeployment
                                                 if ($isAdmin)
                                                     {
                                                         Write-Verbose -Message $("Installing {0} for all users (administrator privileges detected)..." -f $module)
-                                                        Install-Module -Name $module -Repository PSGallery -Scope AllUsers -Force -AllowClobber -Confirm:$false
+                                                        Install-Module -Name $module -Repository PSGallery -Scope AllUsers -Force -AllowClobber -Confirm:$false -Verbose:$false
                                                     }
                                                 else
                                                     {
                                                         Write-Verbose -Message $("Installing {0} for current user (no administrator privileges)..." -f $module)
-                                                        Install-Module -Name $module -Repository PSGallery -Scope CurrentUser -Force -AllowClobber -Confirm:$false
+                                                        Install-Module -Name $module -Repository PSGallery -Scope CurrentUser -Force -AllowClobber -Confirm:$false -Verbose:$false
                                                     }
                                             }
 

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -710,6 +710,9 @@ function Test-SilkResourceDeployment
         begin
             {
                 $StartTime = Get-Date
+                Write-Verbose -Message $("=== Starting Silk Resource Deployment Test Script ===")
+                Write-Verbose -Message $("Script started at: {0}" -f $StartTime.ToString("yyyy-MM-dd HH:mm:ss"))
+
 
                 # Define required Azure PowerShell modules
                 # Import only the specific modules needed instead of the entire Az module for faster loading
@@ -2540,6 +2543,9 @@ function Test-SilkResourceDeployment
                 Start-Sleep -Milliseconds 250
                 [System.Console]::Out.Flush()
 
+                # get timespan to report on deployment duration
+                $DeploymentTimespan = New-TimeSpan -Start $StartTime -End (Get-Date)
+
                 # Comprehensive resource validation and reporting
                 Write-Host "`n=== Post-Deployment Validation ===" -ForegroundColor Cyan
 
@@ -3367,6 +3373,7 @@ function Test-SilkResourceDeployment
                         Write-Host $("📊 Deployment Readiness: Limited - Review validation findings in summary") -ForegroundColor Red
                     }
 
+                Write-Host $("⏱️ Total Deployment Time: {0}" -f $DeploymentTimespan.ToString("hh\:mm\:ss")) -ForegroundColor Cyan
                 Write-Progress -Id 1 -Completed
 
                 # ===============================================================================
@@ -4008,7 +4015,7 @@ function Test-SilkResourceDeployment
         </div>
 
         <div class="timestamp">
-            Report generated on $($StartTime.ToString("yyyy-MM-dd HH:mm:ss")) by Silk Test-SilkResourceDeployment PowerShell module
+            ⏱️ Total Deployment Time: $($DeploymentTimespan.ToString("hh\:mm\:ss")) | Report generated on $($StartTime.ToString("yyyy-MM-dd HH:mm:ss")) by Silk Test-SilkResourceDeployment PowerShell module
         </div>
     </div>
 </body>
@@ -4017,8 +4024,8 @@ function Test-SilkResourceDeployment
 
                                 # Write HTML content to file
                                 $htmlContent | Out-File -FilePath $ReportFullPath -Encoding UTF8
-                                Write-Host "✓ HTML report generated successfully!" -ForegroundColor Green
-                                Write-Host "📄 Report saved to: $ReportFullPath" -ForegroundColor Cyan
+                                Write-Host -Message $("✓ HTML report generated successfully!") -ForegroundColor Green
+                                Write-Host -Message $("📄 Report saved to: `"{0}`"" -f $ReportFullPath) -ForegroundColor Cyan
 
                                 # Attempt to open the report automatically (with error handling for headless systems)
                                 try
@@ -4049,7 +4056,7 @@ function Test-SilkResourceDeployment
                                 catch
                                     {
                                         Write-Verbose -Message $("Unable to automatically open HTML report (likely headless system): {0}" -f $_.Exception.Message)
-                                        Write-Host "ℹ️  Report available at: $ReportFullPath" -ForegroundColor Yellow
+                                        Write-Host -Message $("ℹ️  Report available at: ""{0}""" -f $ReportFullPath) -ForegroundColor Yellow
                                     }
                             }
                         catch
@@ -4090,6 +4097,13 @@ function Test-SilkResourceDeployment
                     {
                         Write-Verbose -Message $("Note: Could not restore original warning preference.")
                     }
+
+                # ===============================================================================
+                # Cleanup Phase
+                # ===============================================================================
+                $cleanupStartTime = Get-Date
+
+                Write-Host -Message $("Cleanup Started at: {0}" -f $cleanupStartTime.ToString("yyyy-MM-dd HH:mm:ss")) -ForegroundColor Yellow
 
                 if ( $RunCleanupOnly -or (!$DisableCleanup -and $deploymentStarted))
                     {
@@ -4638,8 +4652,11 @@ function Test-SilkResourceDeployment
                 # notify cleanup complete if it actually cleaned anything up
                 if($cleanupDidRun)
                     {
-                        Write-Host "Cleanup process completed." -ForegroundColor Green
+                        Write-Host -Message $("Cleanup process completed ran for {0}" -f  (New-TimeSpan -Start $cleanupStartTime -End (Get-Date)).ToString("hh\:mm\:ss")) -ForegroundColor Green
                     }
+
+                # notify total runtime
+                Write-Host -message $("⏱️ Total Script Runtime: {0}" -f (New-TimeSpan -Start $StartTime -End (Get-Date)).ToString("hh\:mm\:ss")) -ForegroundColor Cyan
             }
     }
 

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -1254,66 +1254,6 @@ function Test-SilkResourceDeployment
 
 
                 # ===============================================================================
-                # Compute SKU Location and Zone Support Validation
-                # ===============================================================================
-                # Verify that selected SKUs are supported in the target region and availability zone
-                if ($cNodeObject)
-                    {
-                        $cNodeSupportedSKU = $locationSupportedSKU | Where-Object Name -eq $cNodeVMSku
-                        if (!$cNodeSupportedSKU)
-                            {
-                                Write-Error "Unable to identify location for CNode SKU: {0} in region: {1}" -f $cNodeVMSku, $Region
-                                return
-                            } `
-                        elseif ($cNodeSupportedSKU -and $Zone -eq "Zoneless")
-                            {
-                                Write-Verbose -Message $("CNode SKU: {0} is supported in region: {1} without zones." -f $cNodeSupportedSKU.Name, $cNodeSupportedSKU.LocationInfo.Location)
-                            } `
-                        elseif ($cNodeSupportedSKU -and $cNodeSupportedSKU.LocationInfo.Zones -contains $Zone)
-                            {
-                                Write-Verbose -Message $("CNode SKU: {0} is supported in the target zone {1} in region: {2}. All supported zones: {3}" -f $cNodeSupportedSKU.Name, $Zone, $cNodeSupportedSKU.LocationInfo.Location, ($cNodeSupportedSKU.LocationInfo.Zones -join ", "))
-                            } `
-                        elseif ($cNodeSupportedSKU -and $cNodeSupportedSKU.LocationInfo.Zones -notcontains $Zone)
-                            {
-                                Write-Verbose -Message $("CNode SKU: {0} is not supported in the target zone {1} in region: {2}. It is supported in zones: {3}" -f $cNodeSupportedSKU.Name, $Zone, $cNodeSupportedSKU.LocationInfo.Location, ($cNodeSupportedSKU.LocationInfo.Zones -join ", "))
-                            } `
-                        else
-                            {
-                                Write-Warning -Message $("Unable to determine regional support for CNode SKU: {0} in region: {1}." -f $cNodeSupportedSKU.Name, $cNodeSupportedSKU.LocationInfo.Location)
-                            }
-                    }
-
-                if ($MNodeSize)
-                    {
-                        foreach ($supportedMNodeSKU in $mNodeObjectUnique)
-                            {
-                                $mNodeSupportedSKU = $locationSupportedSKU | Where-Object Name -eq $("{0}{1}{2}" -f $supportedMNodeSKU.vmSkuPrefix, $supportedMNodeSKU.vCPU, $supportedMNodeSKU.vmSkuSuffix)
-                                if (!$mNodeSupportedSKU)
-                                    {
-                                        Write-Error "Unable to identify regional support for MNode SKU: {0}{1}{2} in region: {3}" -f $supportedMNodeSKU.vmSkuPrefix, $supportedMNodeSKU.vCPU, $supportedMNodeSKU.vmSkuSuffix, $Region
-                                        return
-                                    } `
-                                elseif ($mNodeSupportedSKU -and $Zone -eq "Zoneless")
-                                    {
-                                        Write-Verbose -Message $("MNode SKU: {0} is supported in region: {1} without zones." -f $mNodeSupportedSKU.Name, $mNodeSupportedSKU.LocationInfo.Location)
-                                    } `
-                                elseif ($mNodeSupportedSKU -and $mNodeSupportedSKU.LocationInfo.Zones -contains $Zone)
-                                    {
-                                        Write-Verbose -Message $("MNode SKU: {0} is supported in the target zone {1} in region: {2}. All supported zones: {3}" -f $mNodeSupportedSKU.Name, $Zone, $mNodeSupportedSKU.LocationInfo.Location, ($mNodeSupportedSKU.LocationInfo.Zones -join ", "))
-                                    } `
-                                elseif ($mNodeSupportedSKU -and $mNodeSupportedSKU.LocationInfo.Zones -notcontains $Zone)
-                                    {
-                                        Write-Verbose -Message $("MNode SKU: {0} is not supported in the target zone {1} in region: {2}. It is supported in zones: {3}" -f $mNodeSupportedSKU.Name, $Zone, $mNodeSupportedSKU.LocationInfo.Location, ($mNodeSupportedSKU.LocationInfo.Zones -join ", "))
-                                    } `
-                                else
-                                    {
-                                        Write-Warning "Unable to determine regional support for MNode SKU: {0} in region: {1}." -f $mNodeSupportedSKU.Name, $mNodeSupportedSKU.LocationInfo.Location
-                                    }
-                            }
-                    }
-
-
-                # ===============================================================================
                 # Zone Alignment Check
                 # 1. verify the AvailabilityZonePeering Feature is registered for the subscription
                 # 2. Make Az rest call to get the zone alignment information
@@ -1413,6 +1353,66 @@ function Test-SilkResourceDeployment
                 else
                     {
                         Write-Verbose -Message $("{0}Availability Zone Alignment Subscription ID is not set; skipping Availability Zone alignment check." -f $messagePrefix)
+                    }
+
+
+                # ===============================================================================
+                # Compute SKU Location and Zone Support Validation
+                # ===============================================================================
+                # Verify that selected SKUs are supported in the target region and availability zone
+                if ($cNodeObject)
+                    {
+                        $cNodeSupportedSKU = $locationSupportedSKU | Where-Object Name -eq $cNodeVMSku
+                        if (!$cNodeSupportedSKU)
+                            {
+                                Write-Error "Unable to identify location for CNode SKU: {0} in region: {1}" -f $cNodeVMSku, $Region
+                                return
+                            } `
+                        elseif ($cNodeSupportedSKU -and $Zone -eq "Zoneless")
+                            {
+                                Write-Verbose -Message $("CNode SKU: {0} is supported in region: {1} without zones." -f $cNodeSupportedSKU.Name, $cNodeSupportedSKU.LocationInfo.Location)
+                            } `
+                        elseif ($cNodeSupportedSKU -and $cNodeSupportedSKU.LocationInfo.Zones -contains $Zone)
+                            {
+                                Write-Verbose -Message $("CNode SKU: {0} is supported in the target zone {1} in region: {2}. All supported zones: {3}" -f $cNodeSupportedSKU.Name, $Zone, $cNodeSupportedSKU.LocationInfo.Location, ($cNodeSupportedSKU.LocationInfo.Zones -join ", "))
+                            } `
+                        elseif ($cNodeSupportedSKU -and $cNodeSupportedSKU.LocationInfo.Zones -notcontains $Zone)
+                            {
+                                Write-Verbose -Message $("CNode SKU: {0} is not supported in the target zone {1} in region: {2}. It is supported in zones: {3}" -f $cNodeSupportedSKU.Name, $Zone, $cNodeSupportedSKU.LocationInfo.Location, ($cNodeSupportedSKU.LocationInfo.Zones -join ", "))
+                            } `
+                        else
+                            {
+                                Write-Warning -Message $("Unable to determine regional support for CNode SKU: {0} in region: {1}." -f $cNodeSupportedSKU.Name, $cNodeSupportedSKU.LocationInfo.Location)
+                            }
+                    }
+
+                if ($MNodeSize)
+                    {
+                        foreach ($supportedMNodeSKU in $mNodeObjectUnique)
+                            {
+                                $mNodeSupportedSKU = $locationSupportedSKU | Where-Object Name -eq $("{0}{1}{2}" -f $supportedMNodeSKU.vmSkuPrefix, $supportedMNodeSKU.vCPU, $supportedMNodeSKU.vmSkuSuffix)
+                                if (!$mNodeSupportedSKU)
+                                    {
+                                        Write-Error $("Unable to identify regional support for MNode SKU: {0}{1}{2} in region: {3}" -f $supportedMNodeSKU.vmSkuPrefix, $supportedMNodeSKU.vCPU, $supportedMNodeSKU.vmSkuSuffix, $Region)
+                                        return
+                                    } `
+                                elseif ($mNodeSupportedSKU -and $Zone -eq "Zoneless")
+                                    {
+                                        Write-Verbose -Message $("MNode SKU: {0} is supported in region: {1} without zones." -f $mNodeSupportedSKU.Name, $mNodeSupportedSKU.LocationInfo.Location)
+                                    } `
+                                elseif ($mNodeSupportedSKU -and $mNodeSupportedSKU.LocationInfo.Zones -contains $Zone)
+                                    {
+                                        Write-Verbose -Message $("MNode SKU: {0} is supported in the target zone {1} in region: {2}. All supported zones: {3}" -f $mNodeSupportedSKU.Name, $Zone, $mNodeSupportedSKU.LocationInfo.Location, ($mNodeSupportedSKU.LocationInfo.Zones -join ", "))
+                                    } `
+                                elseif ($mNodeSupportedSKU -and $mNodeSupportedSKU.LocationInfo.Zones -notcontains $Zone)
+                                    {
+                                        Write-Verbose -Message $("MNode SKU: {0} is not supported in the target zone {1} in region: {2}. It is supported in zones: {3}" -f $mNodeSupportedSKU.Name, $Zone, $mNodeSupportedSKU.LocationInfo.Location, ($mNodeSupportedSKU.LocationInfo.Zones -join ", "))
+                                    } `
+                                else
+                                    {
+                                        Write-Warning $("Unable to determine regional support for MNode SKU: {0} in region: {1}." -f $mNodeSupportedSKU.Name, $mNodeSupportedSKU.LocationInfo.Location)
+                                    }
+                            }
                     }
 
 

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -33,8 +33,8 @@ function Test-SilkResourceDeployment
                 - MNodes: Media nodes that coordinate data operations and storage management
                 - DNodes: Data nodes that store and serve data (deployed as part of MNode groups)
 
-                Function Version: 1.98.9-1.0.1
-                Supporting Silk SDP configurations from version 1.98.9
+                Function Version: 1.98.10-1.0.1
+                Supporting Silk SDP configurations from version 1.98.10
 
             .PARAMETER SubscriptionId
                 Azure Subscription ID where resources will be deployed.

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -877,7 +877,7 @@ function Test-SilkResourceDeployment
                                 # Check if the current context is still valid
                                 try
                                     {
-                                        $testConnection = Get-AzSubscription -SubscriptionId $currentAzContext.Subscription.Id -ErrorAction Stop
+                                        $testConnectionNull = Get-AzSubscription -SubscriptionId $currentAzContext.Subscription.Id -ErrorAction Stop
                                         Write-Verbose -Message $("✓ Azure authentication is valid and active.")
                                     }
                                 catch
@@ -2554,7 +2554,6 @@ function Test-SilkResourceDeployment
                         $nic = $deployedNICs | Where-Object { $_.Name -eq $expectedNICName }
 
                         # Determine availability set status
-                        $cNodeAvSetName = "$ResourceNamePrefix-cnode-avset"
                         $avSetStatus = if ($vm -and $vm.AvailabilitySetReference) { "CNode AvSet" } else { "Not Assigned" }
 
                         # Determine VM provisioning status and check for validation findings
@@ -2629,7 +2628,6 @@ function Test-SilkResourceDeployment
                                 $nic = $deployedNICs | Where-Object { $_.Name -eq $expectedNICName }
 
                                 # Determine availability set status for DNode
-                                $mNodeAvSetName = "$ResourceNamePrefix-mNode-$currentMNode-avset"
                                 $avSetStatus = if ($vm -and $vm.AvailabilitySetReference) { "MNode $currentMNode AvSet" } else { "Not Assigned" }
 
                                 # Determine VM provisioning status and check for validation findings
@@ -2698,7 +2696,6 @@ function Test-SilkResourceDeployment
                 $totalExpectedVMs = $CNodeCount + ($mNodeObject | ForEach-Object { $_.dNodeCount } | Measure-Object -Sum).Sum
                 $successfulVMs = ($deploymentReport | Where-Object { $_.VMStatus -eq "✓ Deployed" }).Count
                 $failedVMs = ($deploymentReport | Where-Object { $_.VMStatus -like "*Failed*" }).Count
-                $inProgressVMs = ($deploymentReport | Where-Object { $_.VMStatus -like "⚠*" }).Count
                 $nonSuccessfulVMs = $deploymentReport | Where-Object { $_.ProvisioningState -ne "Succeeded" -and $_.ProvisioningState -ne "Not Found" }
 
                 # Zone Alignment Reporting Information

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -3323,7 +3323,7 @@ function Test-SilkResourceDeployment
                 else
                     {
                         Write-Host "Zone Alignment: " -NoNewline
-                        Write-Host $("- Not configured") -ForegroundColor Gray
+                        Write-Host $("- Not Applicable") -ForegroundColor Gray
                         Write-Host $("Reason: {0}" -f $zoneAlignmentInfo.AlignmentReason) -ForegroundColor Gray
                     }
 
@@ -3884,7 +3884,7 @@ function Test-SilkResourceDeployment
                                 else
                                     {
                                         $htmlContent += @"
-                <strong>Zone Alignment:</strong> <span class="status-success">- Not configured</span><br>
+                <strong>Zone Alignment:</strong> <span class="status-success">- Not Applicable</span><br>
 "@
                                     }
 

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -1318,7 +1318,7 @@ function Test-SilkResourceDeployment
                 $sectionStep = ""
                 $messagePrefix = $("{0}{1}" -f $(if($processSection){"[{0}] " -f $processSection}else{""}), $(if($sectionStep){"[{0}] " -f $sectionStep}else{""}))
                 Write-Verbose -Message $("{0}Starting zone alignment check." -f $messagePrefix)
-                if ($ZoneAlignmentSubscriptionId -and $Zone -ne "Zoneless")
+                if ($ZoneAlignmentSubscriptionId -and $Zone -ne "Zoneless" -and $ZoneAlignmentSubscriptionId -ne $SubscriptionId)
                     {
                         $sectionStep = "Check AvailabilityZonePeering Feature"
                         $messagePrefix = $("{0}{1}" -f $(if($processSection){"[{0}] " -f $processSection}else{""}), $(if($sectionStep){"[{0}] " -f $sectionStep}else{""}))
@@ -1375,25 +1375,25 @@ function Test-SilkResourceDeployment
                                 $messagePrefix = $("{0}{1}" -f $(if($processSection){"[{0}] " -f $processSection}else{""}), $(if($sectionStep){"[{0}] " -f $sectionStep}else{""}))
                                 if ($DisableZoneAlignment)
                                     {
-                                        Write-Verbose -Message $("{0}Zone Alignment Disabled. For Region: {1} Deployment Subscription: {2} Availability Zone {3} is aligns with Remote Subscription {4} Availability Zone {5}. Using Deployment Subscription: {2} Availability Zone {3}" -f $messagePrefix, $Region, $SubscriptionId, $alignedZone, $ZoneAlignmentSubscriptionId, $remoteZone, $SubscriptionId, $Zone)
+                                        Write-Verbose -Message $("{0}Availability Zone Alignment Disabled. For Region: {1} Deployment Subscription: {2} Availability Zone {3} is aligns with Remote Subscription {4} Availability Zone {5}. Using Deployment Subscription: {2} Availability Zone {3}" -f $messagePrefix, $Region, $SubscriptionId, $alignedZone, $ZoneAlignmentSubscriptionId, $remoteZone, $SubscriptionId, $Zone)
                                     } `
                                 elseif ($alignedZone -and $alignedZone -eq $Zone)
                                     {
-                                        Write-Verbose -Message $("{0}Zones are aligned in Region: {1}. Deployment Subscription: {2} Availability Zone {3} is aligned with Remote Subscription {4} Availability Zone {5}." -f $messagePrefix, $Region, $SubscriptionId, $Zone, $ZoneAlignmentSubscriptionId, $alignedZone)
+                                        Write-Verbose -Message $("{0}Availability Zones are aligned in Region: {1}. Deployment Subscription: {2} Availability Zone {3} is aligned with Remote Subscription {4} Availability Zone {5}." -f $messagePrefix, $Region, $SubscriptionId, $Zone, $ZoneAlignmentSubscriptionId, $alignedZone)
                                     } `
                                 elseif($alignedZone)
                                     {
                                         $Zone = $alignedZone
-                                        Write-Verbose -Message $("{0}Aligning Zone in Region: {1}. Setting Deployment Subscription: {2} Availability Zone to {3} aligning with Remote Subscription {4} Availability Zone {5}." -f $messagePrefix, $Region, $SubscriptionId, $Zone, $ZoneAlignmentSubscriptionId, $remoteZone)
+                                        Write-Verbose -Message $("{0}Aligning Availability Zone in Region: {1}. Setting Deployment Subscription: {2} Availability Zone to {3} aligning with Remote Subscription {4} Availability Zone {5}." -f $messagePrefix, $Region, $SubscriptionId, $Zone, $ZoneAlignmentSubscriptionId, $remoteZone)
                                     } `
                                 else
                                     {
-                                        Write-Warning -Message $("{0}Zone alignment information undetermined for region: {1}. Zone Alignment not disabled but proceeding without zone alignment. Using Deployment Subscription: {2} Availability Zone {3}" -f $messagePrefix, $Region, $SubscriptionId, $Zone)
+                                        Write-Warning -Message $("{0}Availability Zone alignment information undetermined for region: {1}. Availability Zone Alignment not disabled but proceeding without zone alignment. Using Deployment Subscription: {2} Availability Zone {3}" -f $messagePrefix, $Region, $SubscriptionId, $Zone)
                                     }
                             } `
                         catch
                             {
-                                Write-Warning -Message $("{0}Failed to acquire zone alignment information: {1}" -f $messagePrefix, $_.Exception.Message)
+                                Write-Warning -Message $("{0}Failed to acquire Availability Zone alignment information: {1}" -f $messagePrefix, $_.Exception.Message)
                                 return
                             }
 

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -1098,7 +1098,7 @@ function Test-SilkResourceDeployment
                         Write-Verbose -Message $("Running in Development Mode, using reduced CNode configuration for faster deployment.")
                         $cNodeSizeObject = @(
                                                 [pscustomobject]@{vmSkuPrefix = "Standard_D"; vCPU = 2; vmSkuSuffix = "s_v5"; QuotaFamily = "Standard Dsv5 Family vCPUs"; cNodeFriendlyName = "No_Increased_Logical_Capacity"};
-                                                [pscustomobject]@{vmSkuPrefix = "Standard_L"; vCPU = 4; vmSkuSuffix = "s_v3"; QuotaFamily = "Standard Lsv3 Family vCPUs"; cNodeFriendlyName = "Read_Cache_Enabled"};
+                                                [pscustomobject]@{vmSkuPrefix = "Standard_L"; vCPU = 8; vmSkuSuffix = "s_v3"; QuotaFamily = "Standard Lsv3 Family vCPUs"; cNodeFriendlyName = "Read_Cache_Enabled"};
                                                 [pscustomobject]@{vmSkuPrefix = "Standard_E"; vCPU = 2; vmSkuSuffix = "s_v5"; QuotaFamily = "Standard Esv5 Family vCPUs"; cNodeFriendlyName = "Increased_Logical_Capacity"}
                                             )
                     }
@@ -1145,13 +1145,13 @@ function Test-SilkResourceDeployment
                         Write-Verbose -Message $("Running in Development Mode, using reduced MNode/DNode configuration for faster deployment.")
                         $mNodeSizeObject = @(
                                                 [pscustomobject]@{dNodeCount = 1; vmSkuPrefix = "Standard_L"; vCPU = 8;    vmSkuSuffix = "s_v3";   PhysicalSize = 19.5;     QuotaFamily = "Standard Lsv3 Family vCPUs"};
-                                                [pscustomobject]@{dNodeCount = 1; vmSkuPrefix = "Standard_L"; vCPU = 16;   vmSkuSuffix = "s_v3";   PhysicalSize = 39.1;     QuotaFamily = "Standard Lsv3 Family vCPUs"};
-                                                [pscustomobject]@{dNodeCount = 1; vmSkuPrefix = "Standard_L"; vCPU = 32;   vmSkuSuffix = "s_v3";   PhysicalSize = 78.2;     QuotaFamily = "Standard Lsv3 Family vCPUs"};
+                                                [pscustomobject]@{dNodeCount = 1; vmSkuPrefix = "Standard_L"; vCPU = 8;   vmSkuSuffix = "s_v3";   PhysicalSize = 39.1;     QuotaFamily = "Standard Lsv3 Family vCPUs"};
+                                                [pscustomobject]@{dNodeCount = 1; vmSkuPrefix = "Standard_L"; vCPU = 8;   vmSkuSuffix = "s_v3";   PhysicalSize = 78.2;     QuotaFamily = "Standard Lsv3 Family vCPUs"};
                                                 [pscustomobject]@{dNodeCount = 1; vmSkuPrefix = "Standard_L"; vCPU = 2;    vmSkuSuffix = "aos_v4"; PhysicalSize = 14.67;    QuotaFamily = "Standard Laosv4 Family vCPUs"};
-                                                [pscustomobject]@{dNodeCount = 1; vmSkuPrefix = "Standard_L"; vCPU = 4;    vmSkuSuffix = "aos_v4"; PhysicalSize = 29.34;    QuotaFamily = "Standard Laosv4 Family vCPUs"};
-                                                [pscustomobject]@{dNodeCount = 1; vmSkuPrefix = "Standard_L"; vCPU = 8;    vmSkuSuffix = "aos_v4"; PhysicalSize = 58.67;    QuotaFamily = "Standard Laosv4 Family vCPUs"};
-                                                [pscustomobject]@{dNodeCount = 1; vmSkuPrefix = "Standard_L"; vCPU = 12;   vmSkuSuffix = "aos_v4"; PhysicalSize = 88.01;    QuotaFamily = "Standard Laosv4 Family vCPUs"};
-                                                [pscustomobject]@{dNodeCount = 1; vmSkuPrefix = "Standard_L"; vCPU = 16;   vmSkuSuffix = "aos_v4"; PhysicalSize = 117.35;   QuotaFamily = "Standard Laosv4 Family vCPUs"}
+                                                [pscustomobject]@{dNodeCount = 1; vmSkuPrefix = "Standard_L"; vCPU = 2;    vmSkuSuffix = "aos_v4"; PhysicalSize = 29.34;    QuotaFamily = "Standard Laosv4 Family vCPUs"};
+                                                [pscustomobject]@{dNodeCount = 1; vmSkuPrefix = "Standard_L"; vCPU = 2;    vmSkuSuffix = "aos_v4"; PhysicalSize = 58.67;    QuotaFamily = "Standard Laosv4 Family vCPUs"};
+                                                [pscustomobject]@{dNodeCount = 1; vmSkuPrefix = "Standard_L"; vCPU = 2;   vmSkuSuffix = "aos_v4"; PhysicalSize = 88.01;    QuotaFamily = "Standard Laosv4 Family vCPUs"};
+                                                [pscustomobject]@{dNodeCount = 1; vmSkuPrefix = "Standard_L"; vCPU = 2;   vmSkuSuffix = "aos_v4"; PhysicalSize = 117.35;   QuotaFamily = "Standard Laosv4 Family vCPUs"}
                                             )
                     }
 

--- a/Azure/Resource Availability Check/readme.md
+++ b/Azure/Resource Availability Check/readme.md
@@ -158,23 +158,25 @@ Test-SilkResourceDeployment -ChecklistJSON "C:\configs\silk-deployment.json" -Re
 
 ### Advanced Parameters
 
-| Parameter               | Description | Valid Input | Example | Overrides ChecklistJSON |
-|-------------------------|-------------|-------------|---------|-------------------------|
-| `-CNodeSku`             | Explicit CNode VM SKU selection for advanced control.<br><br>Valid options:<br> &nbsp;Increased_Logical_Capacity (Standard_E64s_v5)<br> &nbsp;Read_Cache_Enabled (Standard_L64s_v3)<br> &nbsp;No_Increased_Logical_Capacity (Standard_D64s_v5)<br>Use for scenarios requiring specific SKU control. | <br>"Standard_E64s_v5"<br>"Standard_L64s_v3"<br>"Standard_D64s_v5" | "Standard_E64s_v5" | ⬜️ |
-| `-MNodeSku`             | Array of explicit Azure VM SKUs for MNode/DNode VMs.<br><br>Lsv3 SKUs:<br> &nbsp;Standard_L8s_v3 (19.5 TiB)<br> &nbsp;Standard_L16s_v3 (39.1 TiB)<br> &nbsp;Standard_L32s_v3 (78.2 TiB)<br>Laosv4 SKUs:<br> &nbsp;Standard_L2aos_v4 (14.67 TiB)<br> &nbsp;Standard_L4aos_v4 (29.34 TiB)<br> &nbsp;Standard_L8aos_v4 (58.67 TiB)<br> &nbsp;Standard_L12aos_v4 (88.01 TiB)<br> &nbsp;Standard_L16aos_v4 (117.35 TiB)<br>Use for advanced scenarios requiring specific SKU control. | "Standard_L8s_v3"<br>"Standard_L16s_v3"<br>"Standard_L32s_v3"<br>"Standard_L2aos_v4"<br>"Standard_L4aos_v4"<br>"Standard_L8aos_v4"<br>"Standard_L12aos_v4"<br>"Standard_L16aos_v4" | @("Standard_L16s_v3", "Standard_L32s_v3") | ⬜️ |
-| `-MNodeCount`           | Number of MNode instances to deploy when using explicit SKU selection. | Minimum of 1 -> Maximum of 4 | 2 | ⬜️ |
-| `-NoHTMLReport`         | Disable HTML report generation.<br><br>By default, a comprehensive HTML report is generated summarizing deployment status, quota usage, SKU support, and resource validation results. | Switch<br>(present or not) | `-NoHTMLReport` | ⬜️ |
-| `-ReportOutputPath`     | Path to save the HTML report.<br><br>Default: Current working directory | <br>".\\valid\\ouput\\path\\" | "C:\\results\\ouput\\" | ⬜️ |
-| `-DisableCleanup`       | Prevent automatic cleanup of test resources after validation.<br><br>When specified, test resources remain in Azure for manual inspection or extended testing. | Switch<br>(present or not) | `-DisableCleanup` | ⬜️ |
-| `-RunCleanupOnly`       | Only perform cleanup operations, removing all previously created test resources based on <br>`-ResourceNamePrefix`<br> naming.<br><br>Use to clean up resources from failed deployments or when cleanup was disabled. | Switch<br>(present or not) | `-RunCleanupOnly` | ⬜️ |
-| `-IPRangeCIDR`          | CIDR notation for VNet and subnet IP address range.<br><br>Default: "10.0.0.0/24" (provides 254 usable IP addresses) | <br>"10.0.0.0/24"<br>"192.168.1.0/24" | "10.0.0.0/24" | ☑️ |
-| `-CreateResourceGroup`  | Create resource group by the given name.  It will only be created and deployed to if it does not exist.  It will only be removed by manual confirmation<br><br>Requires elevated Subscription level role assignment. | Switch<br>(present or not) | `-CreateResourceGroup` | ⬜️ |
-| `-VMImageOffer`         | Azure Marketplace image offer for VM operating system.<br><br>Default: "0001-com-ubuntu-server-jammy" (Ubuntu 22.04 LTS) | <br>"0001-com-ubuntu-server-jammy"<br>"0001-com-ubuntu-server-focal" | "0001-com-ubuntu-server-jammy" | ⬜️ |
-| `-VMImagePublisher`     | Azure Marketplace image publisher for VM operating system.<br><br>Default: "Canonical" (official Ubuntu publisher) | <br>"Canonical"<br>"MicrosoftWindowsServer" | "Canonical" | ⬜️ |
-| `-VMImageSku`           | Azure Marketplace image SKU for VM operating system.<br><br>If not specified, automatically selects the latest available SKU with Gen2 preference. | <br>"22_04-lts-gen2"<br>"2019-datacenter" | "22_04-lts-gen2" | ⬜️ |
-| `-VMImageVersion`       | Azure Marketplace image version for VM operating system.<br><br>Default: "latest" (automatically uses most recent image version) | <br>"latest"<br>"2023.08.15" | "latest" | ⬜️ |
-| `-ResourceNamePrefix`   | Prefix string used for all created Azure resource names to enable easy identification and cleanup.<br><br>Default: "sdp-test" | string [a-zA-Z][a-zA-Z0-9-]{14} | "sdp-test" | ⬜️ |
-| `-VMInstanceCredential` | PowerShell credential object containing username and password for VM local administrator account. | <br>PSCredential object<br> | $VMInstanceCredential | ⬜️ |
+| Parameter                     | Description | Valid Input | Example | Overrides ChecklistJSON |
+|-------------------------------|-------------|-------------|---------|-------------------------|
+| `-CNodeSku`                   | Explicit CNode VM SKU selection for advanced control.<br><br>Valid options:<br> &nbsp;Increased_Logical_Capacity (Standard_E64s_v5)<br> &nbsp;Read_Cache_Enabled (Standard_L64s_v3)<br> &nbsp;No_Increased_Logical_Capacity (Standard_D64s_v5)<br>Use for scenarios requiring specific SKU control. | <br>"Standard_E64s_v5"<br>"Standard_L64s_v3"<br>"Standard_D64s_v5" | "Standard_E64s_v5" | ⬜️ |
+| `-MNodeSku`                   | Array of explicit Azure VM SKUs for MNode/DNode VMs.<br><br>Lsv3 SKUs:<br> &nbsp;Standard_L8s_v3 (19.5 TiB)<br> &nbsp;Standard_L16s_v3 (39.1 TiB)<br> &nbsp;Standard_L32s_v3 (78.2 TiB)<br>Laosv4 SKUs:<br> &nbsp;Standard_L2aos_v4 (14.67 TiB)<br> &nbsp;Standard_L4aos_v4 (29.34 TiB)<br> &nbsp;Standard_L8aos_v4 (58.67 TiB)<br> &nbsp;Standard_L12aos_v4 (88.01 TiB)<br> &nbsp;Standard_L16aos_v4 (117.35 TiB)<br>Use for advanced scenarios requiring specific SKU control. | "Standard_L8s_v3"<br>"Standard_L16s_v3"<br>"Standard_L32s_v3"<br>"Standard_L2aos_v4"<br>"Standard_L4aos_v4"<br>"Standard_L8aos_v4"<br>"Standard_L12aos_v4"<br>"Standard_L16aos_v4" | @("Standard_L16s_v3", "Standard_L32s_v3") | ⬜️ |
+| `-MNodeCount`                 | Number of MNode instances to deploy when using explicit SKU selection. | Minimum of 1 -> Maximum of 4 | 2 | ⬜️ |
+| `-NoHTMLReport`               | Disable HTML report generation.<br><br>By default, a comprehensive HTML report is generated summarizing deployment status, quota usage, SKU support, and resource validation results. | Switch<br>(present or not) | `-NoHTMLReport` | ⬜️ |
+| `-ReportOutputPath`           | Path to save the HTML report.<br><br>Default: Current working directory | <br>".\\valid\\ouput\\path\\" | "C:\\results\\ouput\\" | ⬜️ |
+| `-DisableCleanup`             | Prevent automatic cleanup of test resources after validation.<br><br>When specified, test resources remain in Azure for manual inspection or extended testing. | Switch<br>(present or not) | `-DisableCleanup` | ⬜️ |
+| `-RunCleanupOnly`             | Only perform cleanup operations, removing all previously created test resources based on <br>`-ResourceNamePrefix`<br> naming.<br><br>Use to clean up resources from failed deployments or when cleanup was disabled. | Switch<br>(present or not) | `-RunCleanupOnly` | ⬜️ |
+| `-IPRangeCIDR`                | CIDR notation for VNet and subnet IP address range.<br><br>Default: "10.0.0.0/24" (provides 254 usable IP addresses) | <br>"10.0.0.0/24"<br>"192.168.1.0/24" | "10.0.0.0/24" | ☑️ |
+| `-CreateResourceGroup`        | Create resource group by the given name.  It will only be created and deployed to if it does not exist.  It will only be removed by manual confirmation<br><br>Requires elevated Subscription level role assignment. | Switch<br>(present or not) | `-CreateResourceGroup` | ⬜️ |
+| `-VMImageOffer`               | Azure Marketplace image offer for VM operating system.<br><br>Default: "0001-com-ubuntu-server-jammy" (Ubuntu 22.04 LTS) | <br>"0001-com-ubuntu-server-jammy"<br>"0001-com-ubuntu-server-focal" | "0001-com-ubuntu-server-jammy" | ⬜️ |
+| `-VMImagePublisher`           | Azure Marketplace image publisher for VM operating system.<br><br>Default: "Canonical" (official Ubuntu publisher) | <br>"Canonical"<br>"MicrosoftWindowsServer" | "Canonical" | ⬜️ |
+| `-VMImageSku`                 | Azure Marketplace image SKU for VM operating system.<br><br>If not specified, automatically selects the latest available SKU with Gen2 preference. | <br>"22_04-lts-gen2"<br>"2019-datacenter" | "22_04-lts-gen2" | ⬜️ |
+| `-VMImageVersion`             | Azure Marketplace image version for VM operating system.<br><br>Default: "latest" (automatically uses most recent image version) | <br>"latest"<br>"2023.08.15" | "latest" | ⬜️ |
+| `-ResourceNamePrefix`         | Prefix string used for all created Azure resource names to enable easy identification and cleanup.<br><br>Default: "sdp-test" | string [a-zA-Z][a-zA-Z0-9-]{14} | "sdp-test" | ⬜️ |
+| `-VMInstanceCredential`       | PowerShell credential object containing username and password for VM local administrator account. | <br>PSCredential object<br> | $VMInstanceCredential | ⬜️ |
+| `-ZoneAlignmentSubscriptionId`| Azure Subscription ID for cross-subscription availability zone alignment validation.<br><br>Enables zone alignment to ensure the closest representation of a production deployment that can be tested when deploying across multiple subscriptions by comparing zone mappings between the deployment subscription and this alignment subscription. Requires AvailabilityZonePeering Azure feature registration in both subscriptions.<br><br>When using ChecklistJSON with specified -Subscription parameter, this parameter is automatically populated from the Checklist JSON if not specified. | GUID format subscription ID | "87654321-4321-4321-4321-210987654321" | ☑️ |
+| `-DisableZoneAlignment`       | Disable automatic cross-subscription availability zone alignment.<br><br>By default, zone alignment is performed when ZoneAlignmentSubscriptionId is provided or when using ChecklistJSON configuration with a different deployment subscription specified. Use this switch to maintain original zone settings without alignment adjustments for production deployment testing accuracy. | Switch<br>(present or not) | `-DisableZoneAlignment` | ⬜️ |
 
 ---
 
@@ -214,4 +216,23 @@ Test-SilkResourceDeployment -SubscriptionId "12345678-1234-1234-1234-12345678901
 Test-SilkResourceDeployment  -ChecklistJSON "C:\configs\silk-deployment.json" -ResourceGroupName "silk-test-rg" -RunCleanupOnly -ResourceNamePrefix "custom-name"
 ```
    >Removes all test resources created in the given Subscription (imported from JSON) Resource Group (overriding JSON Resource Group Value) based on the value of `-ResourceNamePrefix` (Default: "sdp-test").
+
+#### 4.1 Advanced: Cross-Subscription Zone Alignment with Explicit Parameters
+```powershell
+Test-SilkResourceDeployment -SubscriptionId "12345678-1234-1234-1234-123456789012" -ResourceGroupName "silk-test-rg" -Region "eastus" -Zone "1" -ZoneAlignmentSubscriptionId "87654321-4321-4321-4321-210987654321" -CNodeFriendlyName "Increased_Logical_Capacity" -CNodeCount 2 -MnodeSizeLaosv4 @("14.67","29.34") -Verbose
+```
+   >Tests deployment with explicit zone alignment between deployment subscription and alignment subscription. Automatically adjusts deployment zone to ensure the closest representation of a production deployment that can be tested. Requires AvailabilityZonePeering feature registration in both subscriptions.
+
+#### 4.2 Advanced: JSON Configuration with Zone Alignment Disabled
+```powershell
+Test-SilkResourceDeployment -ChecklistJSON "C:\configs\silk-deployment.json" -SubscriptionId "12345678-1234-1234-1234-123456789012" -DisableZoneAlignment -Verbose
+```
+   >Uses JSON configuration but deploys to a different subscription than specified in JSON. Explicitly disables automatic zone alignment to maintain original zone settings despite cross-subscription deployment scenario.
+
+#### 4.3 Advanced: Automatic Zone Alignment via JSON Configuration
+```powershell
+Test-SilkResourceDeployment -ChecklistJSON "C:\configs\silk-deployment.json" -SubscriptionId "12345678-1234-1234-1234-123456789012" -Verbose
+```
+   >Uses JSON configuration with automatic zone alignment enabled. When deployment subscription differs from JSON subscription, zone alignment is automatically applied using the JSON subscription as the alignment reference to ensure the closest representation of a production deployment that can be tested.
+
 ---


### PR DESCRIPTION
- function can now check against another subscription for zone alignment and will automatically align for a more analogous test.
- a new switch parameter will disable the zone alignment but still report on the zone alignment
- also improved terminology used reporting status and related suggestions and information.
- included handling for PV2 submit via checklist json as they're not supported by the function currently.
- updated documentation accordingly