### PR TITLE
Azure Prerequiste Help Documentation Update

### DIFF
--- a/Azure/NSG Rule JSONs/README.md
+++ b/Azure/NSG Rule JSONs/README.md
@@ -1,13 +1,15 @@
-# Example Method for Flex NSG Deployment
+# Network Security Group (NSG) Configuration for Silk Flex
 
-This readme offers a method to deploy an NSG and configure it's rules to prepare for a Silk Flex deployment.  The configuration provided in the example json can be directly used with minor changes to suit your environment.  The rules in the example configuration assume limited access within the scope of the VNET is permissible.
+This readme offers a method to deploy an NSG and configure its rules to prepare for a Silk Flex deployment. The configuration provided in the example JSON files can be directly used with minor changes to suit your environment. The rules in the example configuration assume limited access within the scope of the VNET is permissible.
 
+---
 
-## prerequisites for deploying the Flex NSG
+## Prerequisites for Deploying the Flex NSG
 It's assumed you've established an authenticated powershell session to azure and are operating in that session for the entirety of this process. You can use `Connect-AzAccount` to establish that connection and would need to do this in each powershell session you operate out of.
 
-## NSG Example Files Required Changes
-### example flex nsg configuration changes
+## NSG Example Files - Required Changes
+
+### Example Flex NSG Configuration Changes
 The first three values from the [example-flex-nsg-configuration](example-flex-nsg-configuration.json) can be updated according to your environment.
 Update "resource_group_name", "azure_region", and the "name" of the NSG as needed.
 
@@ -20,7 +22,7 @@ Update "resource_group_name", "azure_region", and the "name" of the NSG as neede
 ...
 ```
 
-### example Silk Cluster NSG configuration changes
+### Example Silk Cluster NSG Configuration Changes
 The first three values from the [example-silk-cluster-nsg-configuration](example-silk-cluster-nsg-configuration.json) can be updated according to your environment.
 Update "resource_group_name", "azure_region", "cluster_number", and each of the "cidr" values in the "subnet_config" hashtables to match your environments configuration.
 ```json
@@ -39,24 +41,33 @@ Update "resource_group_name", "azure_region", "cluster_number", and each of the 
 ```
 
 
-# powershell deployment
-This assumes the modified json file is in your working directory.  Update the `-Path` accordingly.
+# PowerShell Deployment
+
+This assumes the modified JSON file is in your working directory. Update the `-Path` accordingly.
+
 ## Flex Subnet NSG
-### import the modified example-flex-nsg-configuration.json configuration into a powershell object
+
+### Import the Modified example-flex-nsg-configuration.json Configuration into a PowerShell Object
 ```powershell
 $config = Get-Content -Path .\example-flex-nsg-configuration.json -Raw | ConvertFrom-Json -Depth 100
 ```
 
+---
+
 ## *OR*
 
+---
+
 ## Silk Cluster Subnet NSGs
-### import the modified example-silk-cluster-nsg-configuration.json configuration into a powershell object
+
+### Import the Modified example-silk-cluster-nsg-configuration.json Configuration into a PowerShell Object
 ```powershell
 $config = Get-Content -Path .\example-silk-cluster-nsg-configuration.json -Raw | ConvertFrom-Json -Depth 100
 ```
 
-## Powershell Command to Deploy from imported config
-### create the new network security groups (nsg) and rules
+## PowerShell Command to Deploy from Imported Config
+
+### Create the New Network Security Groups (NSG) and Rules
 ```powershell
 foreach ($nsg in $config.nsg)
     {

--- a/Azure/Role JSONs/README.md
+++ b/Azure/Role JSONs/README.md
@@ -1,16 +1,18 @@
-# Example Roles for Minimum Required Permissions
+# Azure RBAC Roles for Silk Flex Deployments
 
-This readme offers a method to generate roles required for a Silk Flex Azure Marketplace deployment and ongoing operation for an environment using User Managed Identities.  The role definition json files can be used to create the roles with minimal changes which adapt them to your environment.  The role assignments will also be outlined in this readme.
+This readme offers a method to generate roles required for a Silk Flex Azure Marketplace deployment and ongoing operation for an environment using User Managed Identities. The role definition JSON files can be used to create the roles with minimal changes which adapt them to your environment. The role assignments will also be outlined in this readme.
 
 ---
+
 ## Create Roles
-### prerequisites for deploying the Roles
+
+### Prerequisites for Deploying the Roles
 It's assumed you've established an authenticated powershell session to azure and are operating in that session for the entirety of this process. You can use `Connect-AzAccount` to establish that connection and would need to do this in each powershell session you operate out of.
 
 
-### example configuration changes
+### Example Configuration Changes
 The following values from any of the role json can be updated according to your environments values.
-`  "name": "example-silk-umi-nsg-role",`  
+`  "name": "example-silk-umi-nsg-role",`
 The assignable scopes will vary but update the resource accordingly.
 ```json
   "assignableScopes": [
@@ -18,23 +20,27 @@ The assignable scopes will vary but update the resource accordingly.
   ]
 ```
 
-### powershell deployment
-#### Create Azure Role from Modified json
+### PowerShell Deployment
+
+#### Create Azure Role from Modified JSON
 Update `-InputFile` parameter value with path to the appropriately modified json.  Repeat this for each role needed to be created in preparation for the flex deployment.
 ```powershell
 New-AzRoleDefinition -InputFile .\example....json
 ```
+
 ---
+
 ## Role Assignments
+
 ### Operator Roles
 If the user performing the deployment has owner access to the empty Resource Group which the Silk Flex deployment will target or has higher privilege then no roles need to be created or assigned to the operator.  The operator roles are only required for the deployment, these roles allow only the necessary access is granted to the operator.
-- [Deployment Resource Group Role](example-silk-deployment-operator-resource-group-role.json)
+- [Deployment Resource Group Role](example-silk-deployment-operator-flex-rg-role.json)
   - Created with the assignable scope of the empty Resource Group.
   - Assigned to the deployment operator on the empty Resource Group.
 - [Deployment Subscription Role](example-silk-deployment-operator-subscription-role.json)
   - Created with the assignable scope of the Subscription which the target Resource Group is created.
   - Assigned to the scope of the Subscription which the target Resource Group is created.
-- [Deployment VNET Resource Group Role](example-silk-deployment-operator-vnet-resource-group-role.json)
+- [Deployment VNET Resource Group Role](example-silk-deployment-operator-vnet-role.json)
   - Created with the assignable scope of the Resource Group that the VNET will be/has been created.
   - Assigned to the scope of the Resource Group that the VNET will be/has been created.
 
@@ -45,10 +51,7 @@ If the deployment will use a User Managed Identity instead of the default System
   - Assigned to the UMI on the empty Flex Resource Group.
 - [UMI NSG Role](example-silk-umi-nsg-role.json)
   - Created with the assignable scope of the Resource Group that the NSGs will be/have been created.
-  - Assigned to the UMI on each of the NSG resources.
-- [UMI NSG Resource Group Role](example-silk-umi-nsg-rg-role.json)
-  - Created with the assignable scope of the Resource Group that the NSGs will be/have been created.
-  - Assigned to the UMI on the NSG resource group.
+  - Assigned to the UMI on each of the NSG resources and the NSG resource group.
 - [UMI VNET Role](example-silk-umi-vnet-role.json)
   - Created with the assignable scope of the Resource Group that the VNET will be/has been created.
   - Assigned to the UMI on the VNET resource.

--- a/Azure/UMI/README.md
+++ b/Azure/UMI/README.md
@@ -2,9 +2,9 @@
 
 Silk Flex deployments on Azure can utilize either a System Managed Identity (SMI) or a User Managed Identity (UMI).
 For either deployment method, if the account used during the deployment can not have `owner` role assignment to the Resource Group these roles detail the minimum required permissions to deploy from the Azure marketplace:
-- [resource-group-role](../Role%20JSONs/example-silk-deployment-operator-resource-group-role.json)
+- [resource-group-role](../Role%20JSONs/example-silk-deployment-operator-flex-rg-role.json)
 - [subscription-role](../Role%20JSONs/example-silk-deployment-operator-subscription-role.json)
-- [vnet-resource-group-role](../Role%20JSONs/example-silk-deployment-operator-vnet-resource-group-role.json)
+- [vnet-resource-group-role](../Role%20JSONs/example-silk-deployment-operator-vnet-role.json)
 
 ### UMI vs SMI Deployments
 
@@ -76,7 +76,6 @@ Custom Azure RBAC roles must be created and assigned to the User Managed Identit
 **Required Roles:**
 - [**UMI Flex Resource Group Role**](../Role%20JSONs/example-silk-umi-flex-rg-role.json) - Permissions to create and manage compute resources in the empty Flex resource group
 - [**UMI NSG Role**](../Role%20JSONs/example-silk-umi-nsg-role.json) - Read and write permissions on Network Security Groups
-- [**UMI NSG Resource Group Role**](../Role%20JSONs/example-silk-umi-nsg-rg-role.json) - Resource group level permissions for Network Security Groups
 - [**UMI VNET Role**](../Role%20JSONs/example-silk-umi-vnet-role.json) - Subnet join and read permissions on the Virtual Network
 - [**UMI Object Role**](../Role%20JSONs/example-silk-umi-object-role.json) - (Optional) - Grants permissions for the User Managed Identity (UMI) to assign itself to new Flex instances during the upgrade process.
 - [**UMI Subscription Logs Role**](../Role%20JSONs/example-silk-umi-subscription-logs-role.json) - (Optional) - Activity log read permissions at the subscription level
@@ -84,7 +83,6 @@ Custom Azure RBAC roles must be created and assigned to the User Managed Identit
 **Assignment Requirements:**
 - **UMI Flex Resource Group Role** → Assigned to UMI on the empty target resource group
 - **UMI NSG Role** → Assigned to UMI on each NSG resource
-- **UMI NSG Resource Group Role** → Assigned to UMI on the NSG resource group
 - **UMI VNET Role** → Assigned to UMI on the VNET resource
 - **UMI Object Role** → (Optional) - Assigned to UMI on the UMI object resource
 - **UMI Subscription Logs Role** → (Optional) - Assigned to UMI on the subscription

--- a/Azure/VNET Subnet JSONs/README.md
+++ b/Azure/VNET Subnet JSONs/README.md
@@ -1,16 +1,18 @@
-# Example Method for Flex Subnet Deployment
+# Virtual Network Subnet Configuration for Silk Flex
 
-This readme describes how to configure a subnet to prepare for a Silk Flex deployment and offers a method to deploy that resource via powershell.  The configuration provided in the example json files can be directly used with minor changes to suit your environment.  The examples assume an existing VNET with the corresponding IP ranges is already created.  It's also assumes [appropriately configured network security groups](<../NSG Rule JSONs/README.md>) have been created to associate to the respective subnet.
+This readme describes how to configure a subnet to prepare for a Silk Flex deployment and offers a method to deploy that resource via PowerShell. The configuration provided in the example JSON files can be directly used with minor changes to suit your environment. The examples assume an existing VNET with the corresponding IP ranges is already created. It also assumes [appropriately configured network security groups](<../NSG Rule JSONs/README.md>) have been created to associate to the respective subnet.
 
 ---
-## prerequisites for deploying the Flex Subnet
+
+## Prerequisites for Deploying the Flex Subnet
 It's assumed you've established an authenticated powershell session to azure and are operating in that session for the entirety of this process. You can use `Connect-AzAccount` to establish that connection and would need to do this in each powershell session you operate out of.
 
 
-## example configuration
-This configuration example specifies all required elements for a flex subnet, including the Microsoft.Storage.Global and Microsoft.ContainerRegistry service endpoints where applicable.  It assumes the required network security groups have been created and these subnets are being created in an existing vnet.
+## Example Configuration
 
-### example values to change
+This configuration example specifies all required elements for a flex subnet, including the Microsoft.Storage.Global and Microsoft.ContainerRegistry service endpoints where applicable. It assumes the required network security groups have been created and these subnets are being created in an existing VNET.
+
+### Example Values to Change
 The following values from the [smi-example-flex-subnet-configuration](smi-example-flex-subnet-configuration.json) or [umi-example-silk-cluster-subnet-configuration](umi-example-silk-cluster-subnet-configuration.json) can be updated according to your environment.
 
 ```json
@@ -25,26 +27,30 @@ The following values from the [smi-example-flex-subnet-configuration](smi-exampl
 ```
 
 
-### static example values
-The following values from the [example-flex-subnet-configuration](example-flex-subnet-configuration.json) are constant for any Azure flex or management subnet deployment.<br>
+### Static Example Values
+The following values from the example subnet configuration files are constant for any Azure flex or management subnet deployment.<br>
 `    "subnet_service_endpoint": ["Microsoft.Storage.Global", "Microsoft.ContainerRegistry"]`
 
 
-## powershell deployment
+## PowerShell Deployment
+
 ### SMI
-#### import the smi-example-flex-subnet-configuration.json configuration into a powershell object
+
+#### Import the smi-example-flex-subnet-configuration.json Configuration into a PowerShell Object
 This assumes the modified json file is in your working directory.  Update the `-Path` accordingly.
 ```powershell
 $config = Get-Content -Path .\smi-example-flex-subnet-configuration.json -Raw | ConvertFrom-Json -Depth 100
 ```
+
 ### UMI
-#### import the umi-example-silk-cluster-subnet-configuration.json configuration into a powershell object
+
+#### Import the umi-example-silk-cluster-subnet-configuration.json Configuration into a PowerShell Object
 This assumes the modified json file is in your working directory.  Update the `-Path` accordingly.
 ```powershell
 $config = Get-Content -Path .\umi-example-silk-cluster-subnet-configuration.json -Raw | ConvertFrom-Json -Depth 100
 ```
 
-### create the new subnets
+### Create the New Subnets
 ```powershell
 foreach ($subnet in $config.subnet_config)
     {


### PR DESCRIPTION
fix(docs): Fix broken links and improve formatting in Azure documentation

BREAKING FIXES:
- Fixed broken file references to match actual filenames in repository
- Corrected Role JSONs README links:
  * example-silk-deployment-operator-resource-group-role.json → example-silk-deployment-operator-flex-rg-role.json
  * example-silk-deployment-operator-vnet-resource-group-role.json → example-silk-deployment-operator-vnet-role.json
  * Removed references to non-existent example-silk-umi-nsg-rg-role.json (consolidated into NSG role)
- Fixed UMI README links to deployment operator roles
- Removed reference to non-existent example-flex-subnet-configuration.json in VNET Subnet JSONs README

IMPROVEMENTS:
- Standardized section header capitalization across all README files
- Improved document titles for clarity:
  * NSG: "Network Security Group (NSG) Configuration for Silk Flex"
  * Roles: "Azure RBAC Roles for Silk Flex Deployments"
  * VNET: "Virtual Network Subnet Configuration for Silk Flex"
- Enhanced PowerShell section formatting consistency
- Fixed grammar and typos (e.g., "it's rules" → "its rules")
- Improved readability with consistent formatting patterns

FILES MODIFIED:
- Azure/NSG Rule JSONs/README.md (35 lines changed)
- Azure/Role JSONs/README.md (29 lines changed)
- Azure/UMI/README.md (6 lines changed)
- Azure/VNET Subnet JSONs/README.md (30 lines changed)

All documentation links are now functional and pointing to existing files.
All README files follow consistent formatting and capitalization standards.