### PR TITLE
docs: add TestAllZones with deployment config example

### DIFF
--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -313,6 +313,14 @@ function Test-SilkResourceDeployment
                 Deploys test VMs for each SKU in every supported zone and produces a multi-zone deployment
                 results matrix showing per-zone pass/fail status for each SKU family.
 
+            .EXAMPLE
+                Test-SilkResourceDeployment -SubscriptionId "12345678-1234-1234-1234-123456789012" -ResourceGroupName "silk-test-rg" -Region "eastus" -Zone "1" -CNodeFriendlyName "Increased_Logical_Capacity" -CNodeCount 2 -MnodeSizeLsv3 @("19.5","39.1") -TestAllZones
+
+                Tests a specific deployment configuration across all availability zones simultaneously.
+                Deploys the full CNode and MNode configuration into every zone where all requested SKUs are
+                supported, producing a multi-zone deployment comparison showing pass/fail per zone.
+                The -Zone parameter is still used for zone alignment reporting.
+
             .INPUTS
                 Command line parameters or JSON configuration file containing deployment specifications.
                 Supports both individual parameter specification and bulk configuration via JSON import.

--- a/Azure/Resource Availability Check/readme.md
+++ b/Azure/Resource Availability Check/readme.md
@@ -185,6 +185,12 @@ Test-SilkResourceDeployment -SubscriptionId "12345678-1234-1234-1234-12345678901
 ```
    >Tests all Silk-supported VM SKU families across all availability zones in the region. Deploys test VMs for each SKU in every zone and produces a multi-zone deployment results matrix.
 
+#### 10. Test Deployment Configuration Across All Zones
+```powershell
+Test-SilkResourceDeployment -SubscriptionId "12345678-1234-1234-1234-123456789012" -ResourceGroupName "silk-test-rg" -Region "eastus" -Zone "1" -CNodeFriendlyName "Increased_Logical_Capacity" -CNodeCount 2 -MnodeSizeLsv3 @("19.5","39.1") -TestAllZones
+```
+   >Tests a specific deployment configuration across all availability zones simultaneously. Deploys the full CNode and MNode configuration into every zone where all requested SKUs are supported, producing a multi-zone deployment comparison showing pass/fail per zone. The `-Zone` parameter is still used for zone alignment reporting.
+
 ---
 
 ### Additional Notes


### PR DESCRIPTION
Adds Example 10 demonstrating how to use `-TestAllZones` with a standard deployment configuration (CNode + MNode) to simultaneously test all availability zones.

**Changes:**
- Module `.EXAMPLE` added to `Test-SilkResourceDeployment.psm1`
- README Example 10 added to `readme.md`

Previously we only had `-TestAllZones` paired with `-TestAllSKUFamilies`. This new example shows users how to test a specific production deployment configuration across all 3 AZs in a single run.