### PR TITLE
fix: TestAllZones SKU intersection with skipped zone reporting

### DIFF
--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -1460,6 +1460,7 @@ function Test-SilkResourceDeployment
                                                 TotalFailedVMs          = 0
                                                 VMReport                = @()
                                                 ValidationFindings      = @()
+                                                SkippedZones            = @()
                                                 FindingsAnalysis =     [PSCustomObject]@{
                                                                             NoCapacityIssues    = @()
                                                                             QuotaIssues         = @()
@@ -1997,6 +1998,21 @@ function Test-SilkResourceDeployment
                                     }
                             }
 
+                        # Skipped zones (zones excluded because one or more SKUs are not available there)
+                        if ($ReportData.Deployment.SkippedZones -and $ReportData.Deployment.SkippedZones.Count -gt 0)
+                            {
+                                Write-Host $("`n=== Skipped Zones — Invalid Configuration Zones ===") -ForegroundColor Yellow
+                                Write-Host $("  {0} zone(s) exist in the region but were not tested:" -f $ReportData.Deployment.SkippedZones.Count) -ForegroundColor DarkYellow
+                                foreach ($skipped in $ReportData.Deployment.SkippedZones)
+                                    {
+                                        Write-Host $("  Zone {0}: No deployment attempted" -f $skipped.Zone) -ForegroundColor DarkYellow
+                                        Write-Host $("    Unsupported SKU(s): {0}" -f ($skipped.UnsupportedSKUs -join ", ")) -ForegroundColor Gray
+                                        Write-Host $("    Reason: {0}" -f $skipped.Reason) -ForegroundColor Gray
+                                        Write-Host $("    → This zone cannot host the requested Silk configuration. Select a different SKU set or choose") -ForegroundColor DarkGray
+                                        Write-Host $("      a zone where all required SKUs are available.") -ForegroundColor DarkGray
+                                    }
+                            }
+
                         # Infrastructure resource status
                         $infra = $ReportData.Deployment.Infrastructure
 
@@ -2508,9 +2524,9 @@ function Test-SilkResourceDeployment
 "@
                                                 foreach ($dNode in $group.Group)
                                                     {
-                                                        $vmStatusClass = if ($dNode.VMStatus -like $("*Deployed*")) { $("checkmark") } else { $("error-mark") }
-                                                        $nicStatusClass = if ($dNode.NICStatus -like $("*Created*")) { $("checkmark") } else { $("error-mark") }
-                                                        $provisioningClass = if ($dNode.ProvisioningState -eq $("Succeeded")) { $("checkmark") } elseif ($dNode.ProvisioningState -eq $("Failed")) { $("error-mark") } else { $("warning") }
+                                                        $vmStatusClass = if ($dNode.VMStatus -like $("*✓ Deployed*")) { $("checkmark") } elseif ($dNode.VMStatus -like $("*⚠*")) { $("warning-mark") } else { $("error-mark") }
+                                                        $nicStatusClass = if ($dNode.NICStatus -like $("*Created*")) { $("checkmark") } elseif ($dNode.NICStatus -eq $("—")) { $("warning-mark") } else { $("error-mark") }
+                                                        $provisioningClass = if ($dNode.ProvisioningState -eq $("Succeeded")) { $("checkmark") } elseif ($dNode.ProvisioningState -eq $("Not Attempted")) { $("warning-mark") } elseif ($dNode.ProvisioningState -eq $("Failed")) { $("error-mark") } else { $("warning-mark") }
                                                         $zoneTdHtml = if ($htmlIsMultiZone) { $("{0}                    <td>{1}</td>" -f $("`n"), $dNode.Zone) } else { $("") }
 
                                                         $mNodeTablesHtml += @"
@@ -2960,6 +2976,30 @@ function Test-SilkResourceDeployment
 "@
                                     }
 
+                                # Build Skipped Zones card — zones that exist in the region but cannot host
+                                # this configuration because one or more required SKUs are unavailable there
+                                $skippedZonesHtml = $("")
+                                if ($ReportData.Deployment.SkippedZones -and $ReportData.Deployment.SkippedZones.Count -gt 0)
+                                    {
+                                        $skippedZonesHtml = @"
+            <div class="info-card">
+                <h4>$("⚠️ Skipped Zones — Invalid Configuration Zones")</h4>
+                <strong>$("Note:")</strong> $("The following zone(s) exist in this region but were not tested because one or more required SKUs are not available there. Deployment into these zones would not be possible with the current SKU selection regardless of capacity. To use these zones, select a different VM SKU that is supported across all desired zones.")<br><br>
+"@
+                                        foreach ($skipped in $ReportData.Deployment.SkippedZones)
+                                            {
+                                                $skippedSkuList = $skipped.UnsupportedSKUs -join ", "
+                                                $skippedZonesHtml += @"
+                <strong>$("Zone {0}:" -f $skipped.Zone)</strong> <span class="status-warning">$("⚠ No deployment attempted")</span><br>
+                <strong>$("Unsupported SKU(s):")</strong> $($skippedSkuList)<br>
+                <strong>$("Reason:")</strong> $($skipped.Reason)<br><br>
+"@
+                                            }
+                                        $skippedZonesHtml += @"
+            </div>
+"@
+                                    }
+
                                 # Build SKU Support & Quota Reference HTML (always present when results exist)
                                 # Uses rowspan on Quota Family and Quota Status columns to show shared
                                 # family quota once, spanning all SKU rows that belong to that family.
@@ -3335,6 +3375,7 @@ function Test-SilkResourceDeployment
                 <strong>$("Placement Resources:")</strong> $($networkPPGCount + $infra.AvSetsCreated.Count)
             </div>
             $validationFindingsHtml
+            $skippedZonesHtml
         </div>
 "@
                                     }
@@ -6560,58 +6601,95 @@ function Test-SilkResourceDeployment
                 # ===============================================================================
                 # Multi-Zone Deployment: Determine Target Zones
                 # ===============================================================================
-                # When TestAllZones is specified, find all zones where every requested SKU is
-                # supported and deploy the full configuration into each qualifying zone.
+                # When TestAllZones is specified, find every zone in the region where ALL
+                # requested SKUs are simultaneously supported and deploy only into those zones.
+                # Zones excluded by the SKU intersection are captured as $skippedZoneEntries
+                # and surfaced in the deployment report so the user understands why each zone
+                # was not a valid deployment target for this configuration.
                 # Without TestAllZones, deploy only into the user-specified $Zone.
                 $isMultiZoneDeploy = $false
                 $zonesToDeploy = @($Zone)
+                $skippedZoneEntries = @()
 
                 if ($TestAllZones)
                     {
-                        # Gather all unique SKUs requested in this deployment
-                        $allRequestedSkus = @()
-                        if ($cNodeObject)
+                        # Determine all availability zones present in this region
+                        $allRegionZones = if ($zoneResults -and $zoneResults.Zones.Count -gt 0) `
                             {
-                                $allRequestedSkus += $cNodeVMSku
-                            }
-                        foreach ($mn in $mNodeObject)
-                            {
-                                $mnSkuName = $("{0}{1}{2}" -f $mn.vmSkuPrefix, $mn.vCPU, $mn.vmSkuSuffix)
-                                $allRequestedSkus += $mnSkuName
-                            }
-                        $allRequestedSkus = @($allRequestedSkus | Select-Object -Unique)
-
-                        # Find zones where ALL requested SKUs are supported
-                        $regionSkuZones = @{}
-                        foreach ($sku in $allRequestedSkus)
-                            {
-                                $skuInfo = $locationSupportedSKU | Where-Object { $_.Name -eq $sku -and $_.ResourceType -eq $("virtualMachines") }
-                                $regionSkuZones[$sku] = if ($skuInfo.LocationInfo.Zones) { @($skuInfo.LocationInfo.Zones | Sort-Object) } else { @() }
-                            }
-
-                        # Intersect zones across all SKUs — only deploy to zones that support every SKU
-                        $commonZones = $null
-                        foreach ($sku in $allRequestedSkus)
-                            {
-                                if ($null -eq $commonZones)
-                                    {
-                                        $commonZones = @($regionSkuZones[$sku])
-                                    } `
-                                else
-                                    {
-                                        $commonZones = @($commonZones | Where-Object { $regionSkuZones[$sku] -contains $_ })
-                                    }
-                            }
-
-                        if ($commonZones -and $commonZones.Count -gt 0)
-                            {
-                                $isMultiZoneDeploy = $true
-                                $zonesToDeploy = @($commonZones | Sort-Object)
-                                Write-Verbose -Message $("Multi-zone deployment: {0} zones qualify ({1}) for {2} unique SKUs" -f $zonesToDeploy.Count, ($zonesToDeploy -join $(", ")), $allRequestedSkus.Count)
+                                @($zoneResults.Zones)
                             } `
                         else
                             {
-                                Write-Warning $("No zones found where ALL requested SKUs are supported. Deploying to target zone {0} only." -f $Zone)
+                                @($locationSupportedSKU.LocationInfo.Zones | Sort-Object | Select-Object -Unique)
+                            }
+
+                        if ($allRegionZones.Count -gt 0)
+                            {
+                                # Gather all unique SKUs required by this deployment configuration
+                                $allRequestedSkus = @()
+                                if ($cNodeObject)
+                                    {
+                                        $allRequestedSkus += $cNodeVMSku
+                                    }
+                                foreach ($mn in $mNodeObject)
+                                    {
+                                        $allRequestedSkus += $("{0}{1}{2}" -f $mn.vmSkuPrefix, $mn.vCPU, $mn.vmSkuSuffix)
+                                    }
+                                $allRequestedSkus = @($allRequestedSkus | Select-Object -Unique)
+
+                                # Build per-SKU zone support map from region SKU data
+                                $regionSkuZones = @{}
+                                foreach ($sku in $allRequestedSkus)
+                                    {
+                                        $skuInfo = $locationSupportedSKU | Where-Object { $_.Name -eq $sku -and $_.ResourceType -eq $("virtualMachines") }
+                                        $regionSkuZones[$sku] = if ($skuInfo -and $skuInfo.LocationInfo.Zones) { @($skuInfo.LocationInfo.Zones | Sort-Object) } else { @() }
+                                    }
+
+                                # Intersect zones — only deploy where ALL requested SKUs are supported.
+                                # A zone where even one SKU is unsupported cannot host the full Silk configuration.
+                                $commonZones = $null
+                                foreach ($sku in $allRequestedSkus)
+                                    {
+                                        if ($null -eq $commonZones)
+                                            {
+                                                $commonZones = @($regionSkuZones[$sku])
+                                            } `
+                                        else
+                                            {
+                                                $commonZones = @($commonZones | Where-Object { $regionSkuZones[$sku] -contains $_ })
+                                            }
+                                    }
+                                $commonZones = @($commonZones | Sort-Object)
+
+                                # For every region zone excluded by the intersection, record which SKUs prevented deployment
+                                foreach ($z in $allRegionZones)
+                                    {
+                                        if ($commonZones -notcontains $z)
+                                            {
+                                                $unsupportedSkus = @($allRequestedSkus | Where-Object { $regionSkuZones[$_] -notcontains $z })
+                                                $skippedZoneEntries += [PSCustomObject]@{
+                                                    Zone            = $z
+                                                    UnsupportedSKUs = $unsupportedSkus
+                                                    Reason          = $("Not a valid configuration zone — {0} not available in Zone {1}" -f ($unsupportedSkus -join $(", ")), $z)
+                                                }
+                                                Write-Verbose -Message $("Zone {0} skipped: {1} SKU(s) not supported here ({2})" -f $z, $unsupportedSkus.Count, ($unsupportedSkus -join $(", ")))
+                                            }
+                                    }
+
+                                if ($commonZones.Count -gt 0)
+                                    {
+                                        $isMultiZoneDeploy = $true
+                                        $zonesToDeploy = @($commonZones)
+                                        Write-Verbose -Message $("Multi-zone deployment: {0}/{1} zones qualify ({2}) — {3} zone(s) skipped (invalid configuration for this SKU set)" -f $zonesToDeploy.Count, $allRegionZones.Count, ($zonesToDeploy -join $(", ")), $skippedZoneEntries.Count)
+                                    } `
+                                else
+                                    {
+                                        Write-Warning $("No zones found where ALL requested SKUs are supported. Deploying to target zone {0} only." -f $Zone)
+                                    }
+                            } `
+                        else
+                            {
+                                Write-Warning $("No availability zones detected in region '{0}'. Deploying to target zone {1} only." -f $Region, $Zone)
                             }
                     }
 
@@ -7950,6 +8028,82 @@ function Test-SilkResourceDeployment
                     } # end foreach ($reportZone in $zonesToDeploy)
 
                 # ===============================================================================
+                # Skipped Zone Phantom Report Entries
+                # ===============================================================================
+                # For each zone excluded by the SKU intersection, append informational VMReport
+                # objects so those zones surface as "Not Attempted" rows in the CNode/DNode tables
+                # rather than silently disappearing from the report.
+                if ($skippedZoneEntries.Count -gt 0)
+                    {
+                        foreach ($skippedEntry in $skippedZoneEntries)
+                            {
+                                $skippedZone        = $skippedEntry.Zone
+                                $skippedReason      = $skippedEntry.Reason
+                                $skippedSkuList     = if ($skippedEntry.UnsupportedSKUs) { $($skippedEntry.UnsupportedSKUs -join $(", ")) } else { $("Unknown") }
+                                $skippedZonePrefix  = $("-z{0}" -f $skippedZone)
+                                $notAttemptedStatus = $("⚠ Not Attempted — {0} not available in Zone {1}" -f $skippedSkuList, $skippedZone)
+
+                                # Phantom CNode rows
+                                if ($adjustedCNodeCount -gt 0 -and $cNodeVMSku)
+                                    {
+                                        for ($cNode = 1; $cNode -le $adjustedCNodeCount; $cNode++)
+                                            {
+                                                $deploymentReport += [PSCustomObject]@{
+                                                    ResourceType        = $("CNode")
+                                                    GroupNumber         = $("CNode Group (Zone {0})" -f $skippedZone)
+                                                    NodeNumber          = $cNode
+                                                    VMName              = $("{0}{1}-cnode-{2:D2}" -f $ResourceNamePrefix, $skippedZonePrefix, $cNode)
+                                                    ExpectedSKU         = $cNodeVMSku
+                                                    DeployedSKU         = $("—")
+                                                    VMStatus            = $notAttemptedStatus
+                                                    ProvisioningState   = $("Not Attempted")
+                                                    NICStatus           = $("—")
+                                                    AvailabilitySet     = $("—")
+                                                    ValidationFinding   = $skippedReason
+                                                    FailureCategory     = $("SKU Not In Zone")
+                                                    Zone                = $skippedZone
+                                                }
+                                            }
+                                    }
+
+                                # Phantom DNode rows — one group per MNode config per skipped zone
+                                $skippedDNodeStart  = 0
+                                $skippedMNodeIndex  = 0
+                                foreach ($mNode in $mNodeObject)
+                                    {
+                                        $skippedMNodeIndex++
+                                        $reportMNodeSku   = $("{0}{1}{2}" -f $mNode.vmSkuPrefix, $mNode.vCPU, $mNode.vmSkuSuffix)
+                                        $reportDNodeCount = $mNode.dNodeCount
+                                        if ($mNodeQuotaAdjustments.ContainsKey($mNode.PhysicalSize))
+                                            {
+                                                $reportDNodeCount = $mNodeQuotaAdjustments[$mNode.PhysicalSize].AdjustedCount
+                                            }
+
+                                        for ($dNode = 1; $dNode -le $reportDNodeCount; $dNode++)
+                                            {
+                                                $dNodeNumber = $dNode + $skippedDNodeStart
+                                                $deploymentReport += [PSCustomObject]@{
+                                                    ResourceType        = $("DNode")
+                                                    GroupNumber         = $("MNode {0} ({1} TiB) (Zone {2})" -f $skippedMNodeIndex, $mNode.PhysicalSize, $skippedZone)
+                                                    NodeNumber          = $dNodeNumber
+                                                    VMName              = $("{0}{1}-dnode-{2:D2}" -f $ResourceNamePrefix, $skippedZonePrefix, $dNodeNumber)
+                                                    ExpectedSKU         = $reportMNodeSku
+                                                    DeployedSKU         = $("—")
+                                                    VMStatus            = $notAttemptedStatus
+                                                    ProvisioningState   = $("Not Attempted")
+                                                    NICStatus           = $("—")
+                                                    AvailabilitySet     = $("—")
+                                                    ValidationFinding   = $skippedReason
+                                                    FailureCategory     = $("SKU Not In Zone")
+                                                    Zone                = $skippedZone
+                                                }
+                                            }
+                                        $skippedDNodeStart += $reportDNodeCount
+                                    }
+                            }
+                    }
+
+                # ===============================================================================
                 # Report Data Processing and Analysis
                 # ===============================================================================
                 # Centralized data processing for both console and HTML reports
@@ -8390,6 +8544,7 @@ function Test-SilkResourceDeployment
                 $reportData.Deployment.TotalDeployedVMs         = $successfulVMs
                 $reportData.Deployment.TotalFailedVMs           = $failedVMs
                 $reportData.Deployment.VMReport                 = $deploymentReport
+                $reportData.Deployment.SkippedZones             = if ($skippedZoneEntries) { $skippedZoneEntries } else { @() }
                 $reportData.Deployment.ValidationFindings       = if ($deploymentValidationResults) { $deploymentValidationResults } else { @() }
                 $reportData.Deployment.FindingsAnalysis         = [PSCustomObject]@{
                                                                         NoCapacityIssues    = $validationFindings.NoCapacityIssues

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -1412,6 +1412,9 @@ function Test-SilkResourceDeployment
                                                         SubscriptionValid       = $false
                                                         SubscriptionName        = $("")
                                                         RegionValid             = $false
+                                                        RegionDisplayName       = $("")
+                                                        RegionGeography         = $("")
+                                                        RegionPhysicalLocation  = $("")
                                                         ZoneValid               = $false
                                                         AvailableZones          = @()
                                                         ResourceGroupValid      = $false
@@ -2339,9 +2342,9 @@ function Test-SilkResourceDeployment
 
                                 # Build configuration card content
                                 $configCardContent = @"
-                <strong>$("Subscription ID:")</strong> $($ReportData.Configuration.SubscriptionId)<br>
+                <strong>$("Subscription:")</strong> $(if ($ReportData.EnvironmentValidation.SubscriptionName) { $("{0} ({1})" -f $ReportData.EnvironmentValidation.SubscriptionName, $ReportData.Configuration.SubscriptionId) } else { $ReportData.Configuration.SubscriptionId })<br>
                 <strong>$("Resource Group:")</strong> $($ReportData.Configuration.ResourceGroupName)<br>
-                <strong>$("Region:")</strong> $($ReportData.Configuration.Region)<br>
+                <strong>$("Region:")</strong> $(if ($ReportData.EnvironmentValidation.RegionDisplayName) { $("{0} ({1}){2}{3}" -f $ReportData.EnvironmentValidation.RegionDisplayName, $ReportData.Configuration.Region, $(if ($ReportData.EnvironmentValidation.RegionGeography) { " | {0}" -f $ReportData.EnvironmentValidation.RegionGeography } else { "" }), $(if ($ReportData.EnvironmentValidation.RegionPhysicalLocation) { " | {0}" -f $ReportData.EnvironmentValidation.RegionPhysicalLocation } else { "" })) } else { $ReportData.Configuration.Region })<br>
                 <strong>$("Availability Zone:")</strong> $($ReportData.Configuration.Zone)<br>
 "@
 
@@ -3868,6 +3871,8 @@ function Test-SilkResourceDeployment
                         # Check subscription ID
                         $subscriptionCheck = Get-AzSubscription -SubscriptionId $SubscriptionId -ErrorAction Stop
                         Write-Verbose -Message $("Subscription '{0}' was identified with the ID '{1}'." -f $subscriptionCheck.Name, $subscriptionCheck.Id)
+                        $reportData.EnvironmentValidation.SubscriptionValid = $true
+                        $reportData.EnvironmentValidation.SubscriptionName  = $subscriptionCheck.Name
 
                         Update-StagedProgress -SectionName 'EnvironmentValidation' -SectionCurrentStep 1 -SectionTotalSteps 4 `
                             -DetailMessage $("Validating resource group...")
@@ -3948,8 +3953,38 @@ function Test-SilkResourceDeployment
                                 return
                             }
 
+                        # Verify the subscription has access to the specified region before attempting any resource operations.
+                        # Get-AzLocation returns only locations accessible to the current subscription context.
+                        # An inaccessible or non-existent region is not returned, which would cause all subsequent
+                        # resource creation calls to fail with cryptic errors rather than a clear access message.
+                        $accessibleRegion = Get-AzLocation -ErrorAction Stop | Where-Object { $_.Location -eq $Region } | Select-Object -First 1
+
+                        if (-not $accessibleRegion)
+                            {
+                                Write-Error -Message $("Region '{0}' is not accessible to subscription '{1}' ({2}). The region name may be incorrect, or the subscription may not be registered for this region. Verify the region name at https://aka.ms/azureregions and ensure the subscription has been enabled for this region in the Azure portal under Subscription > Resource Providers or by contacting your Azure administrator." -f $Region, $subscriptionCheck.Name, $SubscriptionId)
+                                $validationError = $true
+                                return
+                            }
+
+                        # Region is accessible - populate metadata fields for reporting
+                        $reportData.EnvironmentValidation.RegionValid            = $true
+                        $reportData.EnvironmentValidation.RegionDisplayName      = $accessibleRegion.DisplayName
+                        $reportData.EnvironmentValidation.RegionGeography        = $accessibleRegion.GeographyGroup
+                        $reportData.EnvironmentValidation.RegionPhysicalLocation = if ($accessibleRegion.PhysicalLocation) { $accessibleRegion.PhysicalLocation } else { $("") }
+
+                        Write-Verbose -Message $("✓ Region '{0}' ({1}) is accessible to subscription '{2}'. Geography: {3}{4}." -f $Region, $accessibleRegion.DisplayName, $subscriptionCheck.Name, $accessibleRegion.GeographyGroup, $(if ($accessibleRegion.PhysicalLocation) { " | Physical location: {0}" -f $accessibleRegion.PhysicalLocation } else { $("") }))
+
                         # Check region and get supported SKUs
                         $locationSupportedSKU = Get-AzComputeResourceSku -Location $Region -ErrorAction Stop
+
+                        # Guard against an empty SKU response. This is a distinct failure from region access —
+                        # the region is registered but compute resources cannot be enumerated (e.g., permissions issue).
+                        if (-not $locationSupportedSKU -or $locationSupportedSKU.Count -eq 0)
+                            {
+                                Write-Error -Message $("Region '{0}' ({1}) is accessible but returned no compute SKU data. The subscription may lack permissions to enumerate compute resources in this region (requires Microsoft.Compute/skus/read), or the region may not support compute workloads." -f $Region, $accessibleRegion.DisplayName)
+                                $validationError = $true
+                                return
+                            }
 
                         # Check zone availability
                         if ($Zone -eq "Zoneless" -and $locationSupportedSKU.LocationInfo.Zones.Count -ne 0)
@@ -4115,9 +4150,9 @@ function Test-SilkResourceDeployment
 
                 Write-Verbose -Message $("{0}Querying Azure Resource SKU API to identify maximum availability set fault domains for region '{1}'." -f $messagePrefix, $Region)
 
-                # Query Azure Resource SKU API to determine maximum fault domains supported by the region
-                # Fault domains define the number of physical hardware failure boundaries within an availability set
-                # Most Azure regions support 3 fault domains, but some regions only support 2
+                # Query Azure Resource SKU API to determine maximum fault domains supported by the region.
+                # Fault domains define the number of physical hardware failure boundaries within an availability set.
+                # Most Azure regions support 3 fault domains, but some (e.g. uksouth) only support 2.
                 try
                     {
                         # Define Azure Resource SKU API version for querying compute SKU information
@@ -4128,24 +4163,28 @@ function Test-SilkResourceDeployment
                                                             Authorization = $("Bearer {0}" -f $(ConvertFrom-SecureString -SecureString $(Get-AzAccessToken -ResourceUrl $("https://management.azure.com/")).Token -AsPlainText))
                                                         }
 
-                        # Construct API URI to query compute SKUs for the target subscription
-                        $azureSKUApiUri = $("https://management.azure.com/subscriptions/{0}/providers/Microsoft.Compute/skus?api-version={1}" -f $SubscriptionId, $azureSKUApiVersion)
+                        # Construct API URI to query compute SKUs for the target subscription, filtered to the target region.
+                        $azureSKUApiUri = $("https://management.azure.com/subscriptions/{0}/providers/Microsoft.Compute/skus?api-version={1}&`$filter=location eq '{2}'" -f $SubscriptionId, $azureSKUApiVersion, $Region)
 
-                        # Execute REST API call to retrieve SKU information
+                        # Execute REST API call to retrieve SKU information for the target region.
                         $regionAvailabilitySetSKU = $(Invoke-RestMethod -Method Get -Uri $azureSKUApiUri -Headers $azureSKUApiRequestHeaders).value
 
-                        # Filter SKU response to extract maximum fault domains capability for availability sets in the target region
-                        $maximumFaultDomains = $regionAvailabilitySetSKU | Where-Object -FilterScript {$_.resourceType -eq $("availabilitySets") -and $_.locations -eq $Region} | Select-Object -First 1 | Select-Object -ExpandProperty capabilities | Select-Object -ExpandProperty value
+                        # Filter SKU response to extract maximum fault domains capability for availability sets in the target region.
+                        $maximumFaultDomains = [int]($regionAvailabilitySetSKU | Where-Object -FilterScript {$_.resourceType -eq $("availabilitySets") -and $_.locations -eq $Region} | Select-Object -First 1 | Select-Object -ExpandProperty capabilities | Where-Object {$_.name -eq $("MaximumPlatformFaultDomainCount")} | Select-Object -ExpandProperty value)
+
+                        # Validate that the query returned a usable value. A null/zero result means the API responded
+                        # but returned no availabilitySets entry for this region — treat this as a hard failure rather
+                        # than proceeding on an assumption that could produce an invalid AvSet configuration.
+                        if (-not $maximumFaultDomains -or $maximumFaultDomains -lt 1)
+                            {
+                                throw $("Azure Resource SKU API returned no availabilitySets fault domain data for region '{0}'. The region name may be invalid or the subscription may not have access to this region." -f $Region)
+                            }
 
                         Write-Verbose -Message $("{0}Successfully identified maximum fault domains for region '{1}': {2}" -f $messagePrefix, $Region, $maximumFaultDomains)
                     } `
                 catch
                     {
-                        # Default to 3 fault domains if API query fails
-                        # Conservative default as majority of Azure regions support 3 fault domains
-                        # Only a small subset of regions (e.g., some government or specialized regions) support only 2
-                        $maximumFaultDomains = 3
-                        Write-Warning -Message $("{0}Failed to query Azure Resource SKU API for fault domain information. Defaulting to {1} fault domains. Error: {2}" -f $messagePrefix, $maximumFaultDomains, $_.Exception.Message)
+                        throw $("{0}Unable to determine maximum fault domains for region '{1}'. Cannot safely create Availability Sets without this value. Error: {2}" -f $messagePrefix, $Region, $_.Exception.Message)
                     }
 
 


### PR DESCRIPTION
Zones excluded by SKU intersection now surface as Not Attempted rows in the CNode and DNode deployment tables rather than silently disappearing from the report. Each phantom row shows the zone number, expected SKU, and the reason deployment was not attempted.