### PR TITLE
bugfix: fix existing infra AvSet lookup using hardcoded generated name

### DIFF
--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -7036,7 +7036,8 @@ function Test-SilkResourceDeployment
                                 if ($cNodeAvailabilitySet)
                                     {
                                         # get the cnode availability set to assess its state
-                                        $cNodeAvailabilitySetComplete = Get-AzAvailabilitySet -ResourceGroupName $ResourceGroupName -Name $("{0}{1}-cnode-avset" -f $ResourceNamePrefix, $zonePrefix)
+                                        # Use $cNodeAvailabilitySet.Name to support both newly created and existing infrastructure paths
+                                        $cNodeAvailabilitySetComplete = Get-AzAvailabilitySet -ResourceGroupName $ResourceGroupName -Name $cNodeAvailabilitySet.Name
                                         Write-Verbose -Message $("✓ CNode availability set '{0}' created with {1} CNodes." -f $cNodeAvailabilitySetComplete.Name, $cNodeAvailabilitySetComplete)
                                         Write-Verbose -Message $("✓ CNode availability set '{0}' is assigned to proximity placement group '{1}'." -f $cNodeAvailabilitySetComplete.Name, $cNodeProximityPlacementGroup.Name)
                                     }


### PR DESCRIPTION
When ProximityPlacementGroupName and AvailabilitySetName are provided (existing infrastructure validation path), the post-deployment AvSet status check was re-fetching the availability set using the hardcoded generated name pattern '{ResourceNamePrefix}{zonePrefix}-cnode-avset' instead of the actual existing AvSet name stored in \.Name.

This caused a 404 ResourceNotFound error for the generated name which does not exist, resulting in VM creation jobs failing because \.Id was unresolvable when passed to New-AzVMConfig.

Fix: use \.Name which is correctly set to the
provided AvailabilitySetName for existing infra paths, and to the generated name for fresh deployment paths - covering both cases.