### PR TITLE
fix: populate $deployedVMs inside analyzeFailedVMJobs scriptblock

### DIFF
--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -7459,6 +7459,13 @@ function Test-SilkResourceDeployment
                 # scope; appends findings to $deploymentValidationResults in scope.
                 $analyzeFailedVMJobs =
                     {
+                        # Query current live VMs before evaluating job outcomes.
+                        # This must be done here rather than relying on the outer $deployedVMs variable,
+                        # which is only assigned after all analysis is complete (line ~8605).
+                        # In sequential mode this runs before per-zone cleanup so VMs are still present;
+                        # in parallel mode VMs are still live at this point as well.
+                        $deployedVMs  = Get-AzVM -ResourceGroupName $ResourceGroupName | Where-Object { $_.Name -match $ResourceNamePrefix }
+
                         $finalVMJobs  = Get-Job
                         # Include Completed jobs where the VM was never actually provisioned —
                         # New-AzVM -AsJob can finish with State=Completed even on allocation failure

--- a/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
+++ b/Azure/Resource Availability Check/Test-SilkResourceDeployment.psm1
@@ -41,7 +41,7 @@ function Test-SilkResourceDeployment
                 - MNodes: Media nodes that coordinate data operations and storage management
                 - DNodes: Data nodes that store and serve data (deployed as part of MNode groups)
 
-                Function Version: 1.0.3
+                Function Version: 1.0.4
                 Supporting Silk SDP configurations from Flex: v2.10.86 VisionOS: v8.6.10
 
             .PARAMETER SubscriptionId
@@ -1305,7 +1305,10 @@ function Test-SilkResourceDeployment
 
         begin
             {
-                $StartTime = Get-Date
+                $StartTime     = Get-Date
+                $scriptVersion = '1.0.4'
+
+                Write-Host $("Test-SilkResourceDeployment v{0} — {1}" -f $scriptVersion, $StartTime.ToString("yyyy-MM-dd HH:mm:ss")) -ForegroundColor Cyan
                 Write-Verbose -Message $("=== Starting Silk Resource Deployment Test Script ===")
                 Write-Verbose -Message $("Script started at: {0}" -f $StartTime.ToString("yyyy-MM-dd HH:mm:ss"))
 
@@ -7093,7 +7096,8 @@ function Test-SilkResourceDeployment
                                     {
                                         $isMultiZoneDeploy = $true
                                         $zonesToDeploy = @($commonZones)
-                                        Write-Verbose -Message $("Multi-zone deployment: {0}/{1} zones qualify ({2}) — {3} zone(s) skipped (invalid configuration for this SKU set)" -f $zonesToDeploy.Count, $allRegionZones.Count, ($zonesToDeploy -join $(", ")), $skippedZoneEntries.Count)
+                                        $skippedMsg = if ($skippedZoneEntries.Count -gt 0) { $(" — {0} zone(s) skipped (SKU not supported)" -f $skippedZoneEntries.Count) } else { $("") }
+                                        Write-Verbose -Message $("Multi-zone deployment: deploying to zones {0}{1}" -f ($zonesToDeploy -join ", "), $skippedMsg)
                                     } `
                                 else
                                     {
@@ -7459,11 +7463,6 @@ function Test-SilkResourceDeployment
                 # scope; appends findings to $deploymentValidationResults in scope.
                 $analyzeFailedVMJobs =
                     {
-                        # Query current live VMs before evaluating job outcomes.
-                        # This must be done here rather than relying on the outer $deployedVMs variable,
-                        # which is only assigned after all analysis is complete (line ~8605).
-                        # In sequential mode this runs before per-zone cleanup so VMs are still present;
-                        # in parallel mode VMs are still live at this point as well.
                         $deployedVMs  = Get-AzVM -ResourceGroupName $ResourceGroupName | Where-Object { $_.Name -match $ResourceNamePrefix }
 
                         $finalVMJobs  = Get-Job
@@ -7692,12 +7691,15 @@ function Test-SilkResourceDeployment
                         # ---------------------------------------------------------------
                         # Deploy the full configuration into each target zone.
                         # For single-zone (no TestAllZones), this loops once with the user-specified zone.
+                        $deploymentValidationResults = @()
                         $zoneLoopIndex = 0
                         foreach ($deployZone in $zonesToDeploy)
                             {
                                 $zoneLoopIndex++
                                 $zonePrefix = if ($isMultiZoneDeploy) { $("-z{0}" -f $deployZone) } else { $("") }
                                 $zoneLabel = if ($isMultiZoneDeploy) { $(" [Zone {0} — {1}/{2}]" -f $deployZone, $zoneLoopIndex, $zonesToDeploy.Count) } else { $("") }
+
+                                Write-Verbose -Message $("=== Zone {0} deployment starting ({1}/{2}) ===" -f $deployZone, $zoneLoopIndex, $zonesToDeploy.Count)
 
                                 if ($isMultiZoneDeploy)
                                     {
@@ -7880,7 +7882,7 @@ function Test-SilkResourceDeployment
                                                     Zone = $deployZone
                                                 }
 
-                                                Write-Verbose -Message $("✓ CNode {0} VM creation job started successfully" -f $cNode)
+                                                Write-Verbose -Message $("✓ CNode {0} VM creation job {1} started: VM '{2}', SKU '{3}', Zone {4}" -f $cNode, $cNodeJob.Id, $("{0}{1}-cnode-{2:D2}" -f $ResourceNamePrefix, $zonePrefix, $cNode), $cNodeVMSku, $deployZone)
                                             } `
                                         catch
                                             {
@@ -7893,8 +7895,7 @@ function Test-SilkResourceDeployment
                                         # get the cnode availability set to assess its state
                                         # Use $cNodeAvailabilitySet.Name to support both newly created and existing infrastructure paths
                                         $cNodeAvailabilitySetComplete = Get-AzAvailabilitySet -ResourceGroupName $ResourceGroupName -Name $cNodeAvailabilitySet.Name
-                                        Write-Verbose -Message $("✓ CNode availability set '{0}' created with {1} CNodes." -f $cNodeAvailabilitySetComplete.Name, $cNodeAvailabilitySetComplete)
-                                        Write-Verbose -Message $("✓ CNode availability set '{0}' is assigned to proximity placement group '{1}'." -f $cNodeAvailabilitySetComplete.Name, $cNodeProximityPlacementGroup.Name)
+                                        Write-Verbose -Message $("✓ CNode availability set '{0}' has {1} VM slot(s) registered, assigned to PPG '{2}'" -f $cNodeAvailabilitySetComplete.Name, $cNodeAvailabilitySetComplete.VirtualMachines.Count, $cNodeProximityPlacementGroup.Name)
                                     }
 
                                 # Clean up CNode creation sub-progress bar as this phase is complete
@@ -8080,7 +8081,7 @@ function Test-SilkResourceDeployment
                                                                                             Zone = $deployZone
                                                                                         }
 
-                                                        Write-Verbose -Message $("✓ DNode {0} VM creation job started successfully" -f $dNodeNumber)
+                                                        Write-Verbose -Message $("✓ DNode {0} VM creation job {1} started: VM '{2}', SKU '{3}', Zone {4}, MNode group {5}" -f $dNodeNumber, $dNodeJob.Id, $("{0}{1}-dnode-{2:D2}" -f $ResourceNamePrefix, $zonePrefix, $dNodeNumber), $currentMNodeSku, $deployZone, $currentMNode)
                                                     } `
                                                 catch
                                                     {
@@ -8092,8 +8093,7 @@ function Test-SilkResourceDeployment
                                             {
                                                 # get the mnode availability set to assess its state
                                                 $mNodeAvailabilitySetComplete = Get-AzAvailabilitySet -ResourceGroupName $ResourceGroupName -Name $mNodeAvailabilitySet.Name
-                                                Write-Verbose -Message $("✓ MNode availability set '{0}' created with {1} MNodes." -f $mNodeAvailabilitySetComplete.Name, $mNodeAvailabilitySetComplete)
-                                                Write-Verbose -Message $("✓ MNode availability set '{0}' is assigned to proximity placement group '{1}'." -f $mNodeAvailabilitySetComplete.Name, $mNodeProximityPlacementGroup.Name)
+                                                Write-Verbose -Message $("✓ MNode group {0} availability set '{1}' has {2} VM slot(s) registered, assigned to PPG '{3}'" -f $currentMNode, $mNodeAvailabilitySetComplete.Name, $mNodeAvailabilitySetComplete.VirtualMachines.Count, $mNodeProximityPlacementGroup.Name)
                                             }
 
                                         $mNodeProximityPlacementGroup = $null
@@ -8153,6 +8153,11 @@ function Test-SilkResourceDeployment
                                     -Id 3
 
                                 Start-Sleep -Seconds 2
+
+                                $zoneAllJobs      = Get-Job
+                                $zoneFinalFailed  = $zoneAllJobs | Where-Object { $_.State -eq 'Failed' }
+                                $zoneFinalDone    = $zoneAllJobs | Where-Object { $_.State -eq 'Completed' }
+                                Write-Verbose -Message $("Zone {0} jobs complete: {1} succeeded, {2} failed, {3} total" -f $deployZone, $zoneFinalDone.Count, $zoneFinalFailed.Count, $zoneAllJobs.Count)
 
                                 # Analyze failed jobs for this zone (dot-source to share scope with outer block)
                                 . $analyzeFailedVMJobs
@@ -8243,11 +8248,6 @@ function Test-SilkResourceDeployment
                         # ========================================================================================================
                         # VM creation job monitoring (parallel / non-sequential path)
                         # ========================================================================================================
-                        # $deploymentValidationResults is initialized here for both paths.
-                        # Sequential path populates it per zone via . $analyzeFailedVMJobs inside the loop above.
-                        # Non-sequential path runs the full monitoring loop and analysis below.
-                        $deploymentValidationResults = @()
-
                         if (-not $sequentialZoneRun)
                             {
                                 Write-Verbose -Message $("All NICs created: {0} total" -f (Get-AzNetworkInterface -ResourceGroupName $ResourceGroupName | Where-Object { $_.Name -match $ResourceNamePrefix }).Count)


### PR DESCRIPTION
## Summary
- `$deployedVMs` was only assigned at line ~8605, well after both call sites for `. $analyzeFailedVMJobs` (sequential per-zone ~8151, parallel ~8301)
- With `$deployedVMs` null, every `Completed`-state job passed the VM-not-found check and was misclassified as a failure — producing 156 "Not Found" entries for successfully deployed VMs in sequential runs
- Fix: query live VMs at the top of the scriptblock so it is always self-contained regardless of call site

## Why it appeared to work previously
The bug was introduced in commit `8909de6` alongside the sequential zone feature. The test that validated `8909de6` was an all-failure scenario — no VMs were successfully deployed — so the null `$deployedVMs` never produced false positives. Sequential runs with a healthy subscription (where zones actually succeed) exposed it.

## Test plan
- [ ] `-TestAllZones -TestZonesSequentially` run shows correct ✓ for zones that deploy successfully
- [ ] Genuine allocation failures still show as failed with correct error message
- [ ] Parallel (non-sequential) `-TestAllZones` run unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)