### PR TITLE
rename: ApplyBestPractices.ps1 -> Invoke-SilkHostBestPractices.ps1

### DIFF
--- a/PowerShell/Invoke-SilkHostBestPractices.ps1
+++ b/PowerShell/Invoke-SilkHostBestPractices.ps1
@@ -49,27 +49,27 @@ function Invoke-SilkHostBestPractices {
     Disables session transcript logging. By default a timestamped log is written to $env:TEMP.
 
 .EXAMPLE
-    .\ApplyBestPractices.ps1
+    .\Invoke-SilkHostBestPractices.ps1
 
     Attended run with no route configuration. Applies all MPIO/MSDSM best practices,
     starts the iSCSI service, displays the host IQN, and prompts the operator before
     each required restart. This is the typical starting point for a new host.
 
 .EXAMPLE
-    .\ApplyBestPractices.ps1 -iSCSInicGateway 10.2.0.1 -DataSubnet 10.2.3.0 -DataSubnetMask 255.255.255.240 -InstallPWSHModules -AutoRestart
+    .\Invoke-SilkHostBestPractices.ps1 -iSCSInicGateway 10.2.0.1 -DataSubnet 10.2.3.0 -DataSubnetMask 255.255.255.240 -InstallPWSHModules -AutoRestart
 
     Full automated deployment: applies all best practices, adds a persistent static route
     to the Silk data subnet, installs required PowerShell modules, and restarts without
     prompting. Use this form in RMM tools or deployment scripts.
 
 .EXAMPLE
-    .\ApplyBestPractices.ps1 -AutoRestart
+    .\Invoke-SilkHostBestPractices.ps1 -AutoRestart
 
     Minimal automated run. Applies MPIO/MSDSM best practices and restarts without
     prompting. Skips route configuration and module installation.
 
 .EXAMPLE
-    .\ApplyBestPractices.ps1 -AuditOnly
+    .\Invoke-SilkHostBestPractices.ps1 -AuditOnly
 
     Reports current compliance status without making any changes. Use before or after
     deployment to verify the host meets Silk best practices. Exits with code 1 if any
@@ -78,7 +78,7 @@ function Invoke-SilkHostBestPractices {
 .NOTES
     Must be run as Administrator.
     After an MPIO feature install restart, re-run this script to complete configuration.
-    Can also be dot-sourced and called directly: . .\ApplyBestPractices.ps1; Invoke-SilkHostBestPractices @params
+    Can also be dot-sourced and called directly: . .\Invoke-SilkHostBestPractices.ps1; Invoke-SilkHostBestPractices @params
 #>
 param(
     [Parameter()]


### PR DESCRIPTION
## Summary

- Renames `PowerShell/ApplyBestPractices.ps1` to `PowerShell/Invoke-SilkHostBestPractices.ps1`
- Aligns the filename with the exported function name (`Invoke-SilkHostBestPractices`) per PowerShell Verb-Noun conventions
- Updates all four `.EXAMPLE` paths and the `.NOTES` dot-source example in the help block

No functional changes.